### PR TITLE
Bugix/no notifyPlay after seek

### DIFF
--- a/Code/Comscore/Source/integration/ComscoreAdapter.swift
+++ b/Code/Comscore/Source/integration/ComscoreAdapter.swift
@@ -28,6 +28,7 @@ class THEOComScoreAdapter: NSObject {
     private var currentContentMetadata: SCORStreamingContentMetadata?
     private var inAd: Bool = false
     private var isBuffering: Bool = false
+    private var isSeeking: Bool = false
     private let player: THEOplayer
     private let playerVersion: String
     private let streamingAnalytics = SCORStreamingAnalytics()
@@ -489,6 +490,13 @@ class THEOComScoreAdapter: NSObject {
             streamingAnalytics.notifyBufferStop()
         }
         
+        if (isSeeking) {
+            // player.seeking will already be false by now, so we maintain state in the adapter
+            isSeeking = false
+            if configuration.debug { print("[THEOplayerConnectorComscore] notifyPlay") }
+            streamingAnalytics.notifyPlay()
+        }
+        
         if (inAd) {
             transitionToAdvertisement() // will set ad metadata and notifyPlay if not done already
         } else if (currentAdOffset < 0) {
@@ -512,6 +520,7 @@ class THEOComScoreAdapter: NSObject {
         
         if (comscoreState != .stopped && comscoreState != .initialized) {
             if configuration.debug { print("[THEOplayerConnectorComscore] notifySeekStart") }
+            isSeeking = true
             streamingAnalytics.notifySeekStart()
 
         }

--- a/THEOplayer-Connector-Comscore.podspec
+++ b/THEOplayer-Connector-Comscore.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
       
   s.static_framework = true
   s.swift_versions = ['5.3', '5.4', '5.5', '5.6', '5.7']
-  s.dependency 'ComScore', '~> 6.7.1'
+  s.dependency 'ComScore', '~> 6.10.0'
   s.dependency 'THEOplayerSDK-basic'
 end


### PR DESCRIPTION
- Fixed an issue where no notifyPlay would be called when the player fires a playing event after a seek
- Updated ComScore dependency to version 6.10.0