### PR TITLE
Report ended on BasicEventReporter deinit

### DIFF
--- a/Code/Nielsen/Source/Events/NielsenReporter/BasicEventReporter.swift
+++ b/Code/Nielsen/Source/Events/NielsenReporter/BasicEventReporter.swift
@@ -27,6 +27,10 @@ class BasicEventReporter: BasicEventProcessor {
         self.nielsen = nielsen
     }
     
+    deinit {
+        reportEndedIfPlayed()
+    }
+    
     func sourceChange(event: THEOplayerSDK.SourceChangeEvent, selectedSource: String?) {
         reportEndedIfPlayed()
         currentSourceHasNotYetPlayedSinceSourceChange = true


### PR DESCRIPTION
iOS destroy event is not received by Nielsen connector. Normally that would be the position to call reportEndedIfPlayed()
This fix also calls that method on the deinit of the connector.