### PR TITLE
Fix retain cycles in Conviva Connector

### DIFF
--- a/Code/Conviva/Source/Events/Observers/AdEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/AdEventForwarder.swift
@@ -22,7 +22,7 @@ public struct AdEventForwarder {
         [
             player.addRemovableEventListener(type: PlayerEventTypes.PLAY, listener: filter.conditionalSender(processor.adPlay)),
             player.addRemovableEventListener(type: PlayerEventTypes.PLAYING, listener: filter.conditionalSender(processor.adPlaying)),
-            player.addRemovableEventListener(type: PlayerEventTypes.TIME_UPDATE) {
+            player.addRemovableEventListener(type: PlayerEventTypes.TIME_UPDATE) { [unowned player] in
                 filter.conditionalSender(processor.adTimeUpdate)($0)
                 if let rate = player.renderedFramerate {
                     filter.conditionalSender(processor.adRenderedFramerateUpdate)(rate)
@@ -42,7 +42,7 @@ public struct AdEventForwarder {
                 type: AdsEventTypes.AD_BREAK_END,
                 listener: filter.togglingSender(processor.adBreakEnd, setLetThroughTo: false)
             ),
-            ads.addRemovableEventListener(type: AdsEventTypes.AD_BEGIN) {
+            ads.addRemovableEventListener(type: AdsEventTypes.AD_BEGIN) { [unowned player] in
                 filter.togglingSender(processor.adBegin, setLetThroughTo: true)(AdBeginWithDurationEvent(beginEvent: $0, duration: player.duration))
             },
             ads.addRemovableEventListener(type: AdsEventTypes.AD_END, listener: processor.adEnd),

--- a/Code/Conviva/Source/Events/Observers/BasicEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/BasicEventForwarder.swift
@@ -1,6 +1,6 @@
 //
 //  BasicEventForwarder.swift
-//  
+//
 //
 //  Created by Damiaan Dufaux on 01/09/2022.
 //
@@ -34,7 +34,7 @@ struct BasicEventForwarder {
         [
             player.addRemovableEventListener(type: PlayerEventTypes.PLAY, listener: processor.play),
             player.addRemovableEventListener(type: PlayerEventTypes.PLAYING, listener: processor.playing),
-            player.addRemovableEventListener(type: PlayerEventTypes.TIME_UPDATE) {
+            player.addRemovableEventListener(type: PlayerEventTypes.TIME_UPDATE) { [unowned player] in
                 processor.timeUpdate(event: $0)
                 if let rate = player.renderedFramerate {
                     processor.renderedFramerateUpdate(framerate: rate)
@@ -45,7 +45,7 @@ struct BasicEventForwarder {
             player.addRemovableEventListener(type: PlayerEventTypes.SEEKING, listener: processor.seeking),
             player.addRemovableEventListener(type: PlayerEventTypes.SEEKED, listener: processor.seeked),
             player.addRemovableEventListener(type: PlayerEventTypes.ERROR, listener: processor.error),
-            player.addRemovableEventListener(type: PlayerEventTypes.SOURCE_CHANGE) {
+            player.addRemovableEventListener(type: PlayerEventTypes.SOURCE_CHANGE) { [unowned player] in
                 processor.sourceChange(event: $0, selectedSource: player.src)
             },
             player.addRemovableEventListener(type: PlayerEventTypes.ENDED, listener: processor.ended),


### PR DESCRIPTION
👋 While working on our app I've found an issue that ConvivaConnector leaked passed instance of `THEOplayer`. Adding a few `unowned` modifiers to `AdEventForwarder` fixed my issue. I added it also to `BasicEventForwarder` as I feel that when I write `player.... { player... }` it should definitely be there as the closure is escaping.

I've added `unowned` as in SDK I think it should be preferred is SDKs and I see it throughout the repo. Unluckily I was not able to try it out as my current project doesn't have ads 😞 