### PR TITLE
Process scheme concatenation on String level instead of URL which fai…

### DIFF
--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Extensions/String+Extensions.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Extensions/String+Extensions.swift
@@ -29,8 +29,12 @@ extension String {
         }
     }
     
-    func byConcatingScheme(scheme: URLScheme) -> String {
+    func byConcatenatingScheme(scheme: URLScheme) -> String {
         return scheme.urlScheme + self
+    }
+    
+    func byRemovingScheme(scheme: URLScheme) -> String? {
+        return self.replaceFirst(of: scheme.urlScheme, with: String())
     }
 
 }

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Extensions/URL+Scheme.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Extensions/URL+Scheme.swift
@@ -28,14 +28,4 @@ extension URL {
         }
         return URL(string: self.absoluteString.replacingCharacters(in: range, with: newScheme + "://"))
     }
-    
-    func byConcatingScheme(scheme: URLScheme) -> URL? {
-        let urlStr = self.absoluteString.byConcatingScheme(scheme: scheme)
-        return URL(string: urlStr.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
-    
-    func byRemovingScheme(scheme: URLScheme) -> URL? {
-        let urlStr = self.absoluteString.replaceFirst(of: scheme.urlScheme, with: String())
-        return URL(string: urlStr.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
 }

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/MasterPlaylistParser.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/MasterPlaylistParser.swift
@@ -81,8 +81,8 @@ class MasterPlaylistParser: PlaylistParser {
     
     func appendSubtitlesLines(subtitles: [TextTrackDescription]) {
         for subtitle in subtitles {
-            if let label = subtitle.label, let encodedURL = subtitle.src.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-                let subtitleCustomSchemePath = encodedURL.byConcatingScheme(scheme: URLScheme.subtitlesm3u8)
+            if let label = subtitle.label, let encodedURLString = subtitle.src.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+                let subtitleCustomSchemePath = encodedURLString.byConcatenatingScheme(scheme: URLScheme.subtitlesm3u8)
                 let subtitleLine = "#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"\(self.subtitlesGroupId)\",NAME=\"\(label)\",URI=\"\(subtitleCustomSchemePath)\",LANGUAGE=\"\(subtitle.srclang)\""
                 if let linePosition = self.lastMediaLine {
                     self.constructedManifestArray.insert("\(subtitleLine)", at: linePosition)
@@ -97,9 +97,6 @@ class MasterPlaylistParser: PlaylistParser {
         guard let variantURL = self.getFullURL(from: path) else {
             return path.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        guard let url = variantURL.byConcatingScheme(scheme: URLScheme.variantm3u8) else {
-            return path
-        }
-        return url.absoluteString
+        return variantURL.absoluteString.byConcatenatingScheme(scheme: URLScheme.variantm3u8) 
     }
 }


### PR DESCRIPTION
Process scheme concatenation on String level instead of URL which fails from iOS17:
https://developer.apple.com/documentation/foundation/url/3126806-init

The URL created from string containing 2 schemes, misses the second ':' in '://' to make the URL valid. 