### PR TITLE
Release action

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,0 +1,44 @@
+name: Bump and release
+run-name: Bumping version to ${{ inputs.version }} and releasing 🚀
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to tag'
+        required: true
+        type: string
+      dryRun:
+        description: 'Dry run to only validate without release.'
+        required: false
+        default: true
+        type: boolean
+jobs:
+  Job-1:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "The version argument is ${{ inputs.version }}."
+      - run: echo "Github ref is -> ${github.ref}"
+      # - name: Update the version.json file
+      #   run: |
+      #     sh update_version_json.sh -v ${{ inputs.version }}
+      # - name: Commit and push the changes made to the version.json file
+      #   run: |
+      #     git add version.json
+      #     git commit -m "update version.json"
+      #     git push
+      # - name: Add and push new git tag
+      #   run: |
+      #     git tag ${{ inputs.version }}
+      #     git push origin ${{ inputs.version }}
+      # - name: Print cocoapods session
+      #   env:
+      #     COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      #   run: |
+      #     if [ ${{ inputs.dryRun }} == true ]; then
+      #       echo "This is a dry run, <insert pod spec lint call here>"
+      #     else
+      #       echo "This is a regular run, <insert pod trunk push call here>"
+      #     fi
+      #     pod trunk me

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -74,7 +74,7 @@ jobs:
           fi
           for connector in ${connectors[*]}
           do
-            pod ${{ command }} ${{ connector }} --verbose
+            pod $command $connector --verbose --allow-warnings
           done
   Cleanup:
     needs: Bump-And-Release

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,5 +1,5 @@
 name: Bump and release
-run-name: Bumping version to ${{ inputs.version }} and releasing. (dry run = ${{ inputs.dryRun }}) 🚀
+run-name: ${{ (inputs.version == '' && 'Not bumping version') || format('Bumping version to {0}', inputs.version) }} and ${{ (inputs.dryRun == true && 'validating') || 'releasing' }} ${{ inputs.connectors }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -21,7 +21,6 @@ on:
           - All
           - Utilities
           - Comscore
-          - Conviva-VerizonMedia
           - Conviva
           - SidelaodedSubtitle
 jobs:
@@ -58,9 +57,12 @@ jobs:
             for file in ${files[*]}
             do
               if [[ $file == *.podspec ]]; then
-                connectors+=("$prefix-$file")
+                if [[ $file != *Utilities.podspec && $file != *VerizonMedia.podspec ]]; then
+                  connectors+=("$file")
+                fi
               fi
             done
+            connectors=("$prefix-Utilities.podspec" "${connectors[@]}")
           else
             connectors+=("$prefix-${{ inputs.connectors }}.podspec")
           fi

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -95,8 +95,10 @@ jobs:
         run: |
           sh update_version_json.sh -v $PREVIOUS_VERSION
       - name: Commit and push the changes made to the version.json file
-        if: $(git diff version.json) != ''
         run: |
-          git add version.json
-          git commit -m "update version.json"
-          git push
+          diff=$(git diff version.json)
+          if [[ $diff != '' ]]; then
+            git add version.json
+            git commit -m "update version.json"
+            git push
+          fi

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           sh update_version_json.sh -v $PREVIOUS_VERSION
       - name: Commit and push the changes made to the version.json file
+        if: $(git diff version.json) != ''
         run: |
           git add version.json
           git commit -m "update version.json"

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -22,7 +22,7 @@ on:
           - Utilities
           - Comscore
           - Conviva
-          - SidelaodedSubtitle
+          - SideloadedSubtitle
 jobs:
   Bump-And-Release:
     runs-on: macos-latest

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -26,9 +26,15 @@ on:
 jobs:
   Bump-And-Release:
     runs-on: macos-latest
+    outputs:
+      previousVersion: ${{ steps.store_previous_version.outputs.previousVersion }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - id: store_previous_version
+        run: |
+          previousVersion=$(ruby -r "./version.rb" -e "print_version")
+          echo "previousVersion=$previousVersion" >> "$GITHUB_OUTPUT"
       - name: Update the version.json file
         if: inputs.version != ''
         run: sh update_version_json.sh -v ${{ inputs.version }}
@@ -70,3 +76,26 @@ jobs:
           do
             pod ${{ command }} ${{ connector }} --verbose
           done
+  Cleanup:
+    needs: Bump-And-Release
+    if: (inputs.dryRun == true && inputs.version != '') && (success() || failure())
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Update to latest
+        run: |
+          git fetch --all
+          git pull
+      - name: Remove and unpublish git tag
+        run: git push --delete origin refs/tags/${{ inputs.version }}
+      - name: Update(Revert) the version.json file back to the previous version
+        env:
+          PREVIOUS_VERSION: ${{ needs.Bump-And-Release.outputs.previousVersion }}
+        run: |
+          sh update_version_json.sh -v $PREVIOUS_VERSION
+      - name: Commit and push the changes made to the version.json file
+        run: |
+          git add version.json
+          git commit -m "update version.json"
+          git push

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -63,9 +63,20 @@ jobs:
             for file in ${files[*]}
             do
               if [[ $file == *.podspec ]]; then
-                if [[ $file != *Utilities.podspec && $file != *VerizonMedia.podspec ]]; then
-                  connectors+=("$file")
+                # we add the Utilities later at index 0
+                if [[ $file == *Utilities.podspec ]]; then
+                  continue
                 fi
+                # blacklisted podspecs
+                if [[ $file == *VerizonMedia.podspec || $file == *Nielsen.podspec ]]; then
+                  continue
+                fi
+                # Conviva validation depends on Utilities being available, which does not get published in a dry run
+                # => skip Conviva if dry run
+                if [[ $file == *Conviva.podspec && ${{ inputs.dryRun == true }} ]]; then
+                  continue
+                fi
+                connectors+=("$file")
               fi
             done
             connectors=("$prefix-Utilities.podspec" "${connectors[@]}")

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - run: echo "The version argument is ${{ inputs.version }}."
-      - run: echo "Github ref is -> ${{ github.ref }}"
       - name: Update the version.json file
         run: |
           sh update_version_json.sh -v ${{ inputs.version }}

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
       - id: store_previous_version
         run: |
-          previousVersion=$(ruby -r "./THEOplayer-Connector-Version.rb" -e "print_version")
+          previousVersion=$(ruby -r "./THEOplayer-Connector-Version.rb" -e "print_theoplayer_connector_version")
           echo "previousVersion=$previousVersion" >> "$GITHUB_OUTPUT"
       - name: Update the version.json file
         if: inputs.version != ''

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
       - id: store_previous_version
         run: |
-          previousVersion=$(ruby -r "./version.rb" -e "print_version")
+          previousVersion=$(ruby -r "./THEOplayer-Connector-Version.rb" -e "print_version")
           echo "previousVersion=$previousVersion" >> "$GITHUB_OUTPUT"
       - name: Update the version.json file
         if: inputs.version != ''

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -31,14 +31,16 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Update the version.json file
-        run: |
-          sh update_version_json.sh -v ${{ inputs.version }}
+        if: inputs.version != ''
+        run: sh update_version_json.sh -v ${{ inputs.version }}
       - name: Commit and push the changes made to the version.json file
+        if: inputs.version != ''
         run: |
           git add version.json
           git commit -m "update version.json"
           git push
       - name: Add and push new git tag
+        if: inputs.version != ''
         run: |
           git tag ${{ inputs.version }}
           git push origin ${{ inputs.version }}

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -44,13 +44,27 @@ jobs:
         run: |
           git tag ${{ inputs.version }}
           git push origin ${{ inputs.version }}
-      - name: Print cocoapods session
+      - name: ${{ (inputs.dryRun == true && 'Validate') || 'Release' }} on Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          if [ ${{ inputs.dryRun }} == true ]; then
-            echo "This is a dry run, <insert pod spec lint call here>"
+          # make the command
+          command="${{ (inputs.dryRun == true && 'spec lint') || 'trunk push' }}"
+          # make the list of connectors
+          prefix="THEOplayer-Connector"
+          connectors=()
+          if [ "${{ inputs.connectors }}" == "All" ]; then
+            files=(*)
+            for file in ${files[*]}
+            do
+              if [[ $file == *.podspec ]]; then
+                connectors+=("$prefix-$file")
+              fi
+            done
           else
-            echo "This is a regular run, <insert pod trunk push call here>"
+            connectors+=("$prefix-${{ inputs.connectors }}.podspec")
           fi
-          pod trunk me
+          for connector in ${connectors[*]}
+          do
+            pod ${{ command }} ${{ connector }} --verbose
+          done

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - run: echo "The version argument is ${{ inputs.version }}."
-      - run: echo "Github ref is -> ${github.ref}"
+      - run: echo "Github ref is -> ${{ github.ref }}"
       # - name: Update the version.json file
       #   run: |
       #     sh update_version_json.sh -v ${{ inputs.version }}

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,5 +1,5 @@
 name: Bump and release
-run-name: Bumping version to ${{ inputs.version }} and releasing 🚀
+run-name: Bumping version to ${{ inputs.version }} and releasing. (dry run = ${{ inputs.dryRun }}) 🚀
 on:
   workflow_dispatch:
     inputs:
@@ -13,32 +13,32 @@ on:
         default: true
         type: boolean
 jobs:
-  Job-1:
+  Bump-And-Release:
     runs-on: macos-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
       - run: echo "The version argument is ${{ inputs.version }}."
       - run: echo "Github ref is -> ${{ github.ref }}"
-      # - name: Update the version.json file
-      #   run: |
-      #     sh update_version_json.sh -v ${{ inputs.version }}
-      # - name: Commit and push the changes made to the version.json file
-      #   run: |
-      #     git add version.json
-      #     git commit -m "update version.json"
-      #     git push
-      # - name: Add and push new git tag
-      #   run: |
-      #     git tag ${{ inputs.version }}
-      #     git push origin ${{ inputs.version }}
-      # - name: Print cocoapods session
-      #   env:
-      #     COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-      #   run: |
-      #     if [ ${{ inputs.dryRun }} == true ]; then
-      #       echo "This is a dry run, <insert pod spec lint call here>"
-      #     else
-      #       echo "This is a regular run, <insert pod trunk push call here>"
-      #     fi
-      #     pod trunk me
+      - name: Update the version.json file
+        run: |
+          sh update_version_json.sh -v ${{ inputs.version }}
+      - name: Commit and push the changes made to the version.json file
+        run: |
+          git add version.json
+          git commit -m "update version.json"
+          git push
+      - name: Add and push new git tag
+        run: |
+          git tag ${{ inputs.version }}
+          git push origin ${{ inputs.version }}
+      - name: Print cocoapods session
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          if [ ${{ inputs.dryRun }} == true ]; then
+            echo "This is a dry run, <insert pod spec lint call here>"
+          else
+            echo "This is a regular run, <insert pod trunk push call here>"
+          fi
+          pod trunk me

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -4,14 +4,26 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to tag'
-        required: true
+        description: 'Version to bump and tag. If unset, then skips version bump and tag.'
+        required: false
         type: string
       dryRun:
         description: 'Dry run to only validate without release.'
-        required: false
+        required: true
         default: true
         type: boolean
+      connectors:
+        description: 'Choose the Connector(s)'
+        required: true
+        type: choice
+        default: 'All'
+        options:
+          - All
+          - Utilities
+          - Comscore
+          - Conviva-VerizonMedia
+          - Conviva
+          - SidelaodedSubtitle
 jobs:
   Bump-And-Release:
     runs-on: macos-latest

--- a/THEOplayer-Connector-Version.rb
+++ b/THEOplayer-Connector-Version.rb
@@ -1,10 +1,17 @@
+def versionJson
+  require "json"
+  jsonFile = File.open "./version.json"
+  json = JSON.load jsonFile
+end
+
 def theoplayer_connector_major_minor_version
-  return '6.1'
+  return versionJson["major_minor"]
 end
+
 def theoplayer_connector_bug_version
-  return '1'
+  return versionJson["patch"]
 end
+
 def theoplayer_connector_version
   return theoplayer_connector_major_minor_version + '.' + theoplayer_connector_bug_version
 end
-

--- a/THEOplayer-Connector-Version.rb
+++ b/THEOplayer-Connector-Version.rb
@@ -15,3 +15,7 @@ end
 def theoplayer_connector_version
   return theoplayer_connector_major_minor_version + '.' + theoplayer_connector_bug_version
 end
+
+def print_theoplayer_connector_version
+  puts theoplayer_connector_version
+end

--- a/update_version_json.sh
+++ b/update_version_json.sh
@@ -1,0 +1,18 @@
+while getopts "v:" opt
+do
+   case "$opt" in
+      v ) version="$OPTARG" ;;
+   esac
+done
+if [ -z "$version" ]
+then
+   echo "Missing argument: 'version'. Usage: \$sh update_version_json.sh -v 1.0.0"
+fi
+
+v=$version
+major_minor=${v%.*}
+patch=$((${v##*.}))
+echo $(cat version.json \
+	| jq --arg major_minor "$major_minor" '.major_minor=$major_minor' \
+	| jq --arg patch "$patch" '.patch=$patch') \
+	> version.json

--- a/update_version_json.sh
+++ b/update_version_json.sh
@@ -7,12 +7,12 @@ done
 if [ -z "$version" ]
 then
    echo "Missing argument: 'version'. Usage: \$sh update_version_json.sh -v 1.0.0"
+else
+   v=$version
+   major_minor=${v%.*}
+   patch=$((${v##*.}))
+   echo $(cat version.json \
+      | jq --arg major_minor "$major_minor" '.major_minor=$major_minor' \
+      | jq --arg patch "$patch" '.patch=$patch') \
+      > version.json
 fi
-
-v=$version
-major_minor=${v%.*}
-patch=$((${v##*.}))
-echo $(cat version.json \
-	| jq --arg major_minor "$major_minor" '.major_minor=$major_minor' \
-	| jq --arg patch "$patch" '.patch=$patch') \
-	> version.json

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "", "patch": "0" }
+{ "major_minor": "0.0", "patch": "1" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "0.0", "patch": "1" }
+{ "major_minor": "", "patch": "0" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "6.1", "patch": "1" }
+{ "major_minor": "0.0", "patch": "1" }

--- a/version.json
+++ b/version.json
@@ -1,0 +1,1 @@
+{ "major_minor": "6.1", "patch": "1" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "0.0", "patch": "1" }
+{ "major_minor": "0.0", "patch": "2" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "6.1", "patch": "1" }
+{ "major_minor": "0.0", "patch": "2" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "0.0", "patch": "1" }
+{ "major_minor": "6.1", "patch": "1" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "0.0", "patch": "2" }
+{ "major_minor": "6.1", "patch": "1" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "major_minor": "0.0", "patch": "2" }
+{ "major_minor": "0.0", "patch": "1" }


### PR DESCRIPTION
Adds a GitHub action to automate the validation or the release of a new version.

It first bumps the version.json file, tags the repo with the new version and then runs the Cocoapods requests.

The action is parameterized by:
1. version: the target version to bump to
2. connectors: the connectors that will be processed
3. dryRun: wether to validate (if dry run == true) or release

Note: Nielsen Connector still needs to be released manually (due to private dependency)