### PR TITLE
Bugfix/no redirect on media requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- SideloadedSubtitle
+  - Prevent using HTTP redirects on media requests.
+
 - Conviva
   - Fixed an issue where reported contentInfo was not cleaned up correctly when starting a new viewing session.
   - Fixed an issue where c3.ad.technology was reported as an integer value instead of a string.
@@ -25,11 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Conviva 
+- Conviva
   - Aligned the API to THEOplayer's Android and Web Conviva connectors.
   - Shield Conviva analytics endpoints. All data reporting now happens via the API.
   - Removed the 'report' methods for AssetName and ViewerID. These are replaced by using the setcontentInfo method (for viewerId) and by passing metadata to the sources (for AssetName).
-  
+
 ## Added
 
 - Conviva
@@ -41,13 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Conviva
   - Updated deprecated name for access log notification to fix broken bitrate reporting.
-  
 - Comscore
   - Prevent Comscore connector crash when reporting ad info for a DAI stream
-  
+
 ### Changed
 
-- Conviva 
+- Conviva
   - Dropped the protocol dependency for the external event dispatcher.
 
 ## [6.1.1] - 2023-10-06
@@ -99,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Conviva
   - Reset stored bitrate value on source changes
-  
+
 ### Added
 
 - Conviva
@@ -146,7 +148,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conviva
   - Report bitrates from iOS in kbps to conviva (a231831a)
   - Do not report empty sessions (4257d803)
-
 
 ## [5.0.4] - 2023-04-21
 
@@ -251,7 +252,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nielsen
   - Use `NielsenAppSDK` and `NielsenTVOSAppSDK` dependencies for cocoapod instead of `NielsenAppSDK-XC` (ded687d0)
 
-
 ## [4.3.1] - 2023-03-17
 
 ### Added
@@ -271,7 +271,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Setup target for SPM (33b5ff6c)
 - Conviva
   - Added tvOS platform to cocoapod (d4ea17dc)
-
 
 ### Changed
 
@@ -298,7 +297,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Conviva
   - Automatic reporting of `CIS_SSDK_METADATA_ASSET_NAME` from THEOplayer's `metadata.title` inside the current source's `SourceDescription` (f4c59570)
 
-
 ## [4.1.1] - 2022-10-19
 
 ### Added
@@ -324,4 +322,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [4.3.0]: https://github.com/THEOplayer/iOS-Connector/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/THEOplayer/iOS-Connector/compare/4.1.1...4.2.0
 [4.1.1]: https://github.com/THEOplayer/iOS-Connector/releases/tag/4.1.1
-

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/Podfile
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/Podfile
@@ -1,0 +1,12 @@
+platform :ios, '12.0'
+
+target 'SideloadedTextTracksExample' do
+  # Use the ComscoreConnector that is locally defined in the parent directory
+  pod 'THEOplayer-Connector-SideloadedSubtitle', :path => '../../../'
+
+  # When you want to use a custom THEOplayerSDK build:
+  #  - place your build at '../../../Helpers/TheoPod/Frameworks/THEOplayerSDK.xcframework'
+  #  - uncomment the following line
+  # pod 'THEOplayerSDK-core', :path => '../../../Helpers/TheoPod'
+
+end

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample.xcodeproj/project.pbxproj
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample.xcodeproj/project.pbxproj
@@ -1,0 +1,439 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		25D8A3E12BF2174E009038EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 25D8A3DF2BF2174E009038EB /* Main.storyboard */; };
+		25F4375429BB8493009074BD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F4375329BB8493009074BD /* AppDelegate.swift */; };
+		25F4375629BB8493009074BD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F4375529BB8493009074BD /* SceneDelegate.swift */; };
+		25F4375829BB8493009074BD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F4375729BB8493009074BD /* ViewController.swift */; };
+		25F4375D29BB8494009074BD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 25F4375C29BB8494009074BD /* Assets.xcassets */; };
+		25F4376029BB8494009074BD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 25F4375E29BB8494009074BD /* LaunchScreen.storyboard */; };
+		25F4376A29BB8996009074BD /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F4376929BB8996009074BD /* PlayerView.swift */; };
+		87254DF07D703DD43BB74E74 /* libPods-SideloadedTextTracksExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 91BA91B8312984866AC0ABBE /* libPods-SideloadedTextTracksExample.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		25D8A3E02BF2174E009038EB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		25F4375029BB8493009074BD /* SideloadedTextTracksExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SideloadedTextTracksExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		25F4375329BB8493009074BD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		25F4375529BB8493009074BD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		25F4375729BB8493009074BD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		25F4375C29BB8494009074BD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		25F4375F29BB8494009074BD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		25F4376129BB8494009074BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		25F4376929BB8996009074BD /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		6A390ECE5F25A357DB3A87DB /* Pods-SideloadedTextTracksExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SideloadedTextTracksExample.debug.xcconfig"; path = "Target Support Files/Pods-SideloadedTextTracksExample/Pods-SideloadedTextTracksExample.debug.xcconfig"; sourceTree = "<group>"; };
+		91BA91B8312984866AC0ABBE /* libPods-SideloadedTextTracksExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SideloadedTextTracksExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EFED5EC5751D974DF18E489C /* Pods-SideloadedTextTracksExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SideloadedTextTracksExample.release.xcconfig"; path = "Target Support Files/Pods-SideloadedTextTracksExample/Pods-SideloadedTextTracksExample.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		25F4374D29BB8493009074BD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				87254DF07D703DD43BB74E74 /* libPods-SideloadedTextTracksExample.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		25F4374729BB8493009074BD = {
+			isa = PBXGroup;
+			children = (
+				25F4375229BB8493009074BD /* SideloadedTextTracksExample */,
+				25F4375129BB8493009074BD /* Products */,
+				8B1F3DA4E95F96573B649351 /* Pods */,
+				59AFC4B513AC6832E2B7C153 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		25F4375129BB8493009074BD /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				25F4375029BB8493009074BD /* SideloadedTextTracksExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		25F4375229BB8493009074BD /* SideloadedTextTracksExample */ = {
+			isa = PBXGroup;
+			children = (
+				25F4375329BB8493009074BD /* AppDelegate.swift */,
+				25F4375529BB8493009074BD /* SceneDelegate.swift */,
+				25F4375729BB8493009074BD /* ViewController.swift */,
+				25F4375C29BB8494009074BD /* Assets.xcassets */,
+				25D8A3DF2BF2174E009038EB /* Main.storyboard */,
+				25F4375E29BB8494009074BD /* LaunchScreen.storyboard */,
+				25F4376129BB8494009074BD /* Info.plist */,
+				25F4376929BB8996009074BD /* PlayerView.swift */,
+			);
+			path = SideloadedTextTracksExample;
+			sourceTree = "<group>";
+		};
+		59AFC4B513AC6832E2B7C153 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				91BA91B8312984866AC0ABBE /* libPods-SideloadedTextTracksExample.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8B1F3DA4E95F96573B649351 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				6A390ECE5F25A357DB3A87DB /* Pods-SideloadedTextTracksExample.debug.xcconfig */,
+				EFED5EC5751D974DF18E489C /* Pods-SideloadedTextTracksExample.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		25F4374F29BB8493009074BD /* SideloadedTextTracksExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25F4376429BB8494009074BD /* Build configuration list for PBXNativeTarget "SideloadedTextTracksExample" */;
+			buildPhases = (
+				26C765E8CD38EA5CB9072BF3 /* [CP] Check Pods Manifest.lock */,
+				25F4374C29BB8493009074BD /* Sources */,
+				25F4374D29BB8493009074BD /* Frameworks */,
+				25F4374E29BB8493009074BD /* Resources */,
+				E380EC27919A48246C4008FE /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SideloadedTextTracksExample;
+			productName = SideloadedTextTracksExample;
+			productReference = 25F4375029BB8493009074BD /* SideloadedTextTracksExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		25F4374829BB8493009074BD /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1400;
+				LastUpgradeCheck = 1400;
+				TargetAttributes = {
+					25F4374F29BB8493009074BD = {
+						CreatedOnToolsVersion = 14.0;
+					};
+				};
+			};
+			buildConfigurationList = 25F4374B29BB8493009074BD /* Build configuration list for PBXProject "SideloadedTextTracksExample" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 25F4374729BB8493009074BD;
+			productRefGroup = 25F4375129BB8493009074BD /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				25F4374F29BB8493009074BD /* SideloadedTextTracksExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		25F4374E29BB8493009074BD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25D8A3E12BF2174E009038EB /* Main.storyboard in Resources */,
+				25F4376029BB8494009074BD /* LaunchScreen.storyboard in Resources */,
+				25F4375D29BB8494009074BD /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		26C765E8CD38EA5CB9072BF3 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SideloadedTextTracksExample-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E380EC27919A48246C4008FE /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SideloadedTextTracksExample/Pods-SideloadedTextTracksExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SideloadedTextTracksExample/Pods-SideloadedTextTracksExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SideloadedTextTracksExample/Pods-SideloadedTextTracksExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		25F4374C29BB8493009074BD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				25F4375829BB8493009074BD /* ViewController.swift in Sources */,
+				25F4375429BB8493009074BD /* AppDelegate.swift in Sources */,
+				25F4376A29BB8996009074BD /* PlayerView.swift in Sources */,
+				25F4375629BB8493009074BD /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		25D8A3DF2BF2174E009038EB /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				25D8A3E02BF2174E009038EB /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		25F4375E29BB8494009074BD /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				25F4375F29BB8494009074BD /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		25F4376229BB8494009074BD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		25F4376329BB8494009074BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		25F4376529BB8494009074BD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A390ECE5F25A357DB3A87DB /* Pods-SideloadedTextTracksExample.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = W2ZJUPUUZW;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SideloadedTextTracksExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.theotechnologies.samples.SideloadedTextTracksExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		25F4376629BB8494009074BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EFED5EC5751D974DF18E489C /* Pods-SideloadedTextTracksExample.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = W2ZJUPUUZW;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SideloadedTextTracksExample/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.theotechnologies.samples.SideloadedTextTracksExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		25F4374B29BB8493009074BD /* Build configuration list for PBXProject "SideloadedTextTracksExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25F4376229BB8494009074BD /* Debug */,
+				25F4376329BB8494009074BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		25F4376429BB8494009074BD /* Build configuration list for PBXNativeTarget "SideloadedTextTracksExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				25F4376529BB8494009074BD /* Debug */,
+				25F4376629BB8494009074BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 25F4374829BB8493009074BD /* Project object */;
+}

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/AppDelegate.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/AppDelegate.swift
@@ -1,0 +1,33 @@
+//
+//  AppDelegate.swift
+//  SideloadedTextTracksExample
+//
+//  Created by Wonne Joosen on 13/04/2024.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+}
+

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Assets.xcassets/Contents.json
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Base.lproj/LaunchScreen.storyboard
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Base.lproj/Main.storyboard
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Base.lproj/Main.storyboard
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SideloadedTextTracksExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="r5X-cG-ZbP">
+                                <rect key="frame" x="16" y="47.000000000000028" width="358" height="489.66666666666674"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="O9V-wF-5tz">
+                                        <rect key="frame" x="0.0" y="0.0" width="358" height="223.66666666666666"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="O9V-wF-5tz" secondAttribute="height" multiplier="16:10" id="Svd-nB-EH0"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mgu-sa-Bjv">
+                                        <rect key="frame" x="0.0" y="231.66666666666669" width="91" height="106"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Load:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gd8-Bw-Itz">
+                                                <rect key="frame" x="0.0" y="0.0" width="42" height="30"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B0n-7f-55X">
+                                                <rect key="frame" x="0.0" y="38" width="91" height="30"/>
+                                                <state key="normal" title="SRT Example"/>
+                                                <connections>
+                                                    <action selector="srtButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="leZ-bq-fEP"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="egf-hJ-oar">
+                                                <rect key="frame" x="0.0" y="76" width="91" height="30"/>
+                                                <state key="normal" title="VTT Example"/>
+                                                <connections>
+                                                    <action selector="vttButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ba6-0y-EjA"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Geg-Oe-CuE">
+                                        <rect key="frame" x="0.0" y="345.66666666666669" width="106" height="144"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Actions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OPR-Mj-crQ">
+                                                <rect key="frame" x="0.0" y="0.0" width="57" height="30"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GZi-UD-7pu">
+                                                <rect key="frame" x="0.0" y="38" width="74" height="30"/>
+                                                <state key="normal" title="play/pause"/>
+                                                <connections>
+                                                    <action selector="togglePlayPause:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wex-Mv-j2f"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uaw-Mh-ar0">
+                                                <rect key="frame" x="0.0" y="76" width="69" height="30"/>
+                                                <state key="normal" title="seek +10s"/>
+                                                <connections>
+                                                    <action selector="seekForward:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QUK-yJ-dnp"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zTT-bW-0zr">
+                                                <rect key="frame" x="0.0" y="114" width="106" height="30"/>
+                                                <state key="normal" title="toggle subtitles"/>
+                                                <connections>
+                                                    <action selector="toggleSubtitle:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ipe-OT-0jV"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="O9V-wF-5tz" firstAttribute="height" secondItem="r5X-cG-ZbP" secondAttribute="height" priority="250" id="4U0-ES-0XZ"/>
+                                    <constraint firstItem="O9V-wF-5tz" firstAttribute="width" secondItem="r5X-cG-ZbP" secondAttribute="width" id="DUd-EG-Fqp"/>
+                                </constraints>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="4U0-ES-0XZ"/>
+                                    </mask>
+                                </variation>
+                                <variation key="heightClass=compact-widthClass=compact" alignment="center" axis="horizontal">
+                                    <mask key="constraints">
+                                        <exclude reference="DUd-EG-Fqp"/>
+                                        <include reference="4U0-ES-0XZ"/>
+                                    </mask>
+                                </variation>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="r5X-cG-ZbP" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="cLL-XI-saE"/>
+                            <constraint firstItem="r5X-cG-ZbP" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="gDN-pV-Z99"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="r5X-cG-ZbP" secondAttribute="bottom" id="gpB-Jp-UJR"/>
+                            <constraint firstItem="r5X-cG-ZbP" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="lUg-Rh-oEw"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="gpB-Jp-UJR"/>
+                            </mask>
+                        </variation>
+                        <variation key="heightClass=compact-widthClass=compact">
+                            <mask key="constraints">
+                                <include reference="gpB-Jp-UJR"/>
+                            </mask>
+                        </variation>
+                    </view>
+                    <connections>
+                        <outlet property="playerViewContainer" destination="O9V-wF-5tz" id="5pF-Eu-UpA"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="140" y="25.592417061611375"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Info.plist
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/PlayerView.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/PlayerView.swift
@@ -1,0 +1,32 @@
+//
+//  PlayerView.swift
+//  SideloadedTextTracksExample
+//
+//  Created by Wonne Joosen on 13/04/2024.
+//
+
+import UIKit
+import THEOplayerSDK
+
+/// A container UIView that holds a `THEOPlayer` and lays it out
+/// to stretch the entire frame of this container view
+class PlayerView: UIView {
+    /// The player that is streched out to fit this view
+    let player: THEOplayer
+    
+    required init?(coder: NSCoder) {nil}
+    
+    /// Create a container view that holds a `THEOPlayer` and lays it out
+    /// to stretch its contents to fill the entire frame of the container view.
+    /// - Parameter player: The player that will be laid out in this view
+    init(player: THEOplayer) {
+        self.player = player
+        super.init(frame: player.frame)
+        player.addAsSubview(of: self)
+    }
+        
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        player.frame = bounds
+    }
+}

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/SceneDelegate.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  SideloadedTextTracksExample
+//
+//  Created by Wonne Joosen on 13/04/2024.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
@@ -45,7 +45,7 @@ class ViewController: UIViewController {
         print("[SideloadedTextTracksExample] Setting source with SRT subtitles")
         player.setSourceWithSubtitles(source: SourceDescription(
             source: TypedSource(src: "https://cdn.theoplayer.com/video/elephants-dream/playlist-no-subtitles.m3u8", type: "application/x-mpegurl"),
-            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.nl.srt", srclang: "en", isDefault: false, kind: .subtitles, label: "English", format: .SRT)]
+            textTracks: [SSTextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.nl.srt", srclang: "en", isDefault: false, kind: .subtitles, label: "English", format: .SRT)]
         ))
     }
     
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
         print("[SideloadedTextTracksExample] Setting source with VTT subtitles")
         player.setSourceWithSubtitles(source: SourceDescription(
             source: TypedSource(src: "https://cdn.theoplayer.com/video/elephants-dream/playlist-no-subtitles.m3u8", type: "application/x-mpegurl"),
-            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.en.vtt", srclang: "nl", isDefault: false, kind: .subtitles, label: "Nederlands", format: .WebVTT)]
+            textTracks: [SSTextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.en.vtt", srclang: "nl", isDefault: false, kind: .subtitles, label: "Nederlands", format: .WebVTT)]
         ))
     }
     

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
@@ -45,7 +45,7 @@ class ViewController: UIViewController {
         print("[SideloadedTextTracksExample] Setting source with SRT subtitles")
         player.setSourceWithSubtitles(source: SourceDescription(
             source: TypedSource(src: "https://cdn.theoplayer.com/video/elephants-dream/playlist-no-subtitles.m3u8", type: "application/x-mpegurl"),
-            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.nl.srt", srclang: "en", isDefault: false, kind: .subtitles, label: "English", format: .WebVTT)]
+            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.nl.srt", srclang: "en", isDefault: false, kind: .subtitles, label: "English", format: .SRT)]
         ))
     }
     
@@ -53,7 +53,7 @@ class ViewController: UIViewController {
         print("[SideloadedTextTracksExample] Setting source with VTT subtitles")
         player.setSourceWithSubtitles(source: SourceDescription(
             source: TypedSource(src: "https://cdn.theoplayer.com/video/elephants-dream/playlist-no-subtitles.m3u8", type: "application/x-mpegurl"),
-            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.en.vtt", srclang: "nl", isDefault: false, kind: .subtitles, label: "Nederlands", format: .SRT)]
+            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.en.vtt", srclang: "nl", isDefault: false, kind: .subtitles, label: "Nederlands", format: .WebVTT)]
         ))
     }
     

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
 //            googleIma: GoogleIMAAdsConfiguration(useNativeIma: false)
 //        )))
         let playerConfiguration = THEOplayerConfigurationBuilder()
-        playerConfiguration.license = "<your license>"
+//        playerConfiguration.license = "<your license>"
         self.player = THEOplayer(with: nil, configuration: playerConfiguration.build())
         super.init(coder: coder)
     }

--- a/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
+++ b/Code/Sideloaded-TextTracks-Examples/Cocoapod/SideloadedTextTracksExample/ViewController.swift
@@ -1,0 +1,84 @@
+//
+//  ViewController.swift
+//  SideloadedTextTracksExample
+//
+//  Created by Wonne Joosen on 13/04/2024.
+//
+
+import UIKit
+import THEOplayerSDK
+import THEOplayerConnectorSideloadedSubtitle
+
+class ViewController: UIViewController {
+    
+    
+    @IBOutlet weak var playerViewContainer: UIView!
+    var player: THEOplayer
+    
+    required init?(coder: NSCoder) {
+//        self.player = THEOplayer(with: nil, configuration: THEOplayerConfiguration(chromeless: false, ads: AdsConfiguration(
+//            showCountdown: true,
+//            preload: AdPreloadType.MIDROLL_AND_POSTROLL,
+//            googleIma: GoogleIMAAdsConfiguration(useNativeIma: false)
+//        )))
+        let playerConfiguration = THEOplayerConfigurationBuilder()
+        playerConfiguration.license = "<your license>"
+        self.player = THEOplayer(with: nil, configuration: playerConfiguration.build())
+        super.init(coder: coder)
+    }
+    
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+        
+        let playerView = PlayerView(player: player)
+        playerView.translatesAutoresizingMaskIntoConstraints = true
+        playerView.frame = playerViewContainer.bounds
+        playerView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        playerViewContainer.addSubview(playerView)
+        
+    }
+    
+    
+    @IBAction func srtButtonClicked(_ sender: UIButton) {
+        print("[SideloadedTextTracksExample] Setting source with SRT subtitles")
+        player.setSourceWithSubtitles(source: SourceDescription(
+            source: TypedSource(src: "https://cdn.theoplayer.com/video/elephants-dream/playlist-no-subtitles.m3u8", type: "application/x-mpegurl"),
+            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.nl.srt", srclang: "en", isDefault: false, kind: .subtitles, label: "English", format: .WebVTT)]
+        ))
+    }
+    
+    @IBAction func vttButtonClicked(_ sender: UIButton) {
+        print("[SideloadedTextTracksExample] Setting source with VTT subtitles")
+        player.setSourceWithSubtitles(source: SourceDescription(
+            source: TypedSource(src: "https://cdn.theoplayer.com/video/elephants-dream/playlist-no-subtitles.m3u8", type: "application/x-mpegurl"),
+            textTracks: [TextTrackDescription(src: "https://cdn.theoplayer.com/video/elephants-dream/captions.en.vtt", srclang: "nl", isDefault: false, kind: .subtitles, label: "Nederlands", format: .SRT)]
+        ))
+    }
+    
+    @IBAction func togglePlayPause(_ sender: UIButton) {
+        if (player.paused) {
+            player.play()
+        } else {
+            player.pause()
+        }
+    }
+    
+    @IBAction func toggleSubtitle(_ sender: UIButton) {
+        var textTrack = player.textTracks.get(0)
+        if textTrack.mode == .disabled {
+            print("[SideloadedTextTracksExample] turning on subtitles")
+            textTrack.mode = .showing
+        } else {
+            print("[SideloadedTextTracksExample] turning off subtitles")
+            textTrack.mode = .disabled
+        }
+            
+    }
+    
+    @IBAction func seekForward(_ sender: Any) {
+        self.player.currentTime = self.player.currentTime + 10
+    }
+}
+

--- a/Code/Sideloaded-TextTracks-Examples/README.md
+++ b/Code/Sideloaded-TextTracks-Examples/README.md
@@ -1,0 +1,5 @@
+# THEOPlayer 🤝 Sideloaded TextTracks Samples
+
+We provide source code of two sample applications that illustrate how to use the connector with different package managers:
+
+- [Sample using **Cocoapods**](./Cocoapod) (requires Cocoapods installation through terminal)

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/AVSubtitlesLoader.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/AVSubtitlesLoader.swift
@@ -91,32 +91,17 @@ class AVSubtitlesLoader: NSObject {
         
         return true
     }
-
-    func handleSubtitleContent(_ request: AVAssetResourceLoadingRequest) -> Bool {
-        guard let customSchemeURL = request.request.url else {
-            return false
-        }
-
-        guard let originalURLString = customSchemeURL.absoluteString.byRemovingScheme(scheme: URLScheme.subtitle),
-              let originalURL = URL(string: originalURLString) else {
-            print("[AVSubtitlesLoader] ERROR: Failed to revert subtitle URL!")
-            return false
-        }
-
+    
+    fileprivate func getSubtitleManifest(for originalURL: URL) -> String {
         let trackDescription: THEOplayerSDK.TextTrackDescription? = self.findTrackDescription(by: originalURL)
         let format: THEOplayerSDK.TextTrackFormat = trackDescription?.format ?? .WebVTT
         let timestamp: SSTextTrackDescription.WebVttTimestamp? = (trackDescription as? SSTextTrackDescription)?.vttTimestamp
-        let req: URLRequest? = self.transformer.composeTransformationRequest(with: originalURL.absoluteString, format: format, timestamp: timestamp)
-        let response = HTTPURLResponse(url: originalURL, statusCode: 301, httpVersion: nil, headerFields: nil)
-        request.response = response
-        request.redirect = req
-        request.finishLoading()
-
-        return true
-    }
-    
-    fileprivate func getSubtitleManifest(for originalURL: URL) -> String {
-        let subtitlesURL: String = originalURL.absoluteString.byConcatenatingScheme(scheme: URLScheme.subtitle)
+        let subtitlesMediaURL: String
+        if (timestamp?.localTime == nil && timestamp?.pts == nil) {
+            subtitlesMediaURL = originalURL.absoluteString
+        } else {
+            subtitlesMediaURL = self.transformer.composeTranformationUrl(with: originalURL.absoluteString, format: format, timestamp: timestamp)
+        }
         // if the variantTotalDuration is equal to zero then we can use a higher number as AVPlayer is not expecting the EXACT duration but the MAXIMUM duration that the stream can reach
         return """
         #EXTM3U
@@ -125,7 +110,7 @@ class AVSubtitlesLoader: NSObject {
         #EXT-X-PLAYLIST-TYPE:VOD
         #EXT-X-TARGETDURATION:\(self.variantTotalDuration == 0 ? Int.max : Int(self.variantTotalDuration))
         #EXTINF:\(self.variantTotalDuration == 0 ? String(Int.max) : String(format: "%.3f", self.variantTotalDuration))
-        \(subtitlesURL)
+        \(subtitlesMediaURL)
         #EXT-X-ENDLIST
         """
     }
@@ -193,9 +178,6 @@ extension AVSubtitlesLoader: ManifestInterceptor {
         case URLScheme.subtitlesm3u8.name:
             // intercept the subtitle request to respond with the HLS subtitle
             return self.handleSubtitles(loadingRequest)
-        case URLScheme.subtitle.name:
-            // intercept subtitle content to modify (ie. SRT -> VTT, add time offset, etc.)
-            return self.handleSubtitleContent(loadingRequest)
         default:
             break
         }

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/AVSubtitlesLoader.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/AVSubtitlesLoader.swift
@@ -97,7 +97,7 @@ class AVSubtitlesLoader: NSObject {
         let format: THEOplayerSDK.TextTrackFormat = trackDescription?.format ?? .WebVTT
         let timestamp: SSTextTrackDescription.WebVttTimestamp? = (trackDescription as? SSTextTrackDescription)?.vttTimestamp
         let subtitlesMediaURL: String
-        if (timestamp?.localTime == nil && timestamp?.pts == nil) {
+        if (timestamp?.localTime == nil && timestamp?.pts == nil && format == .WebVTT) {
             subtitlesMediaURL = originalURL.absoluteString
         } else {
             subtitlesMediaURL = self.transformer.composeTranformationUrl(with: originalURL.absoluteString, format: format, timestamp: timestamp)

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/SubtitlesTransformer.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/SubtitlesTransformer.swift
@@ -42,7 +42,7 @@ class SubtitlesTransformer {
         return AVAudioSession.sharedInstance().isConnectedToAirplayDevice() ? (DeviceUtil.DEVICE_IP ?? defaultHost) : defaultHost
     }
 
-    func composeTransformationRequest(with subtitlesURL: String, format: THEOplayerSDK.TextTrackFormat, timestamp: SSTextTrackDescription.WebVttTimestamp?) -> URLRequest {
+    func composeTranformationUrl(with subtitlesURL: String, format: THEOplayerSDK.TextTrackFormat, timestamp: SSTextTrackDescription.WebVttTimestamp?) -> String {
         var urlComps = URLComponents(string: "http://\(self.host):\(self.port)/\(SubtitlesTransformer.TRANSFORM_ROUTE)")!
         urlComps.queryItems = [URLQueryItem(name: Parameters.contentUrl.rawValue, value: subtitlesURL)]
         urlComps.queryItems!.append(URLQueryItem(name: Parameters.format.rawValue, value: format._rawValue))
@@ -52,9 +52,8 @@ class SubtitlesTransformer {
             urlComps.queryItems!.append(URLQueryItem(name: Parameters.timestampPts.rawValue, value: pts))
             urlComps.queryItems!.append(URLQueryItem(name: Parameters.timestampLocaltime.rawValue, value: localTime))
         }
-
-        let req = URLRequest(url: urlComps.url!)
-        return req
+        
+        return urlComps.url?.absoluteString ?? subtitlesURL
     }
 
     private func setupServerRoutes() {


### PR DESCRIPTION
This PR makes the necessary changes to prevent using HTTP redirects on media requests, since it:
- Is not allowed by the [HLS authoring specification](https://developer.apple.com/documentation/http-live-streaming/hls-authoring-specification-for-apple-devices)
```
8.18. Your media requests MUST NOT use HTTP redirects, with the exception of ad content to allow dynamic selection of ads.
```
- Causes problems on third party AirPlay-enabled devices

Instead of using the custom scheme for handling subtitle content, the media playlist for the subtitles contains:
- The original subtitle content url, if `pts` and `localTime` fields were not specified in `SSTextTrackDescription.vttTimestamp`
- The transformation url which we previously redirected to on the subtitle content request