### PR TITLE
Bugfix/srt containing percent encoding and byteranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- SideloadedSubtitle
+  - Fixed an issue where playlists that contain urls with percentEncoding got an extra percentEncoding pass resulting in erronneous urls.
+  - Fixed an issue where variant playlists with additional tags between EXTINF and the segment url, where not properly processed.
+
 ## [7.0.0] - 2024-04-03
 
 ### Changed

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/MasterPlaylistParser.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/MasterPlaylistParser.swift
@@ -45,7 +45,7 @@ class MasterPlaylistParser: PlaylistParser {
         }
         let allLines = manifestString.components(separatedBy: "\n")
         var iterator = allLines.makeIterator()
-        while let lineString = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines) {
+        while let lineString = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
             let line = HLSLine(lineString: lineString)
             // we need this to force-use the absoluteURL in any URI parameter in a line
             // the reason for this behaviour is that AVPlayer will use the custom Scheme if relativeURL is provided
@@ -68,7 +68,7 @@ class MasterPlaylistParser: PlaylistParser {
             case ManifestTags.ExtXStreamInf.rawValue:
                 line.paramsObject[HLSKeywords.subtitles.rawValue] = "\"\(self.subtitlesGroupId)\""
                 self.constructedManifestArray.append(line.joinLine())
-                if let nextLine = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines) {
+                if let nextLine = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
                     let variantURL = self.getVariantURLWithCustomScheme(from: nextLine)
                     self.constructedManifestArray.append(variantURL)
                 }

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/MasterPlaylistParser.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/MasterPlaylistParser.swift
@@ -45,7 +45,7 @@ class MasterPlaylistParser: PlaylistParser {
         }
         let allLines = manifestString.components(separatedBy: "\n")
         var iterator = allLines.makeIterator()
-        while let lineString = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
+        while let lineString = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines) {
             let line = HLSLine(lineString: lineString)
             // we need this to force-use the absoluteURL in any URI parameter in a line
             // the reason for this behaviour is that AVPlayer will use the custom Scheme if relativeURL is provided
@@ -68,7 +68,7 @@ class MasterPlaylistParser: PlaylistParser {
             case ManifestTags.ExtXStreamInf.rawValue:
                 line.paramsObject[HLSKeywords.subtitles.rawValue] = "\"\(self.subtitlesGroupId)\""
                 self.constructedManifestArray.append(line.joinLine())
-                if let nextLine = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
+                if let nextLine = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines) {
                     let variantURL = self.getVariantURLWithCustomScheme(from: nextLine)
                     self.constructedManifestArray.append(variantURL)
                 }

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/VariantPlaylistParser.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/VariantPlaylistParser.swift
@@ -54,26 +54,18 @@ class VariantPlaylistParser: PlaylistParser {
             // the reason for this behaviour is that AVPlayer will use the custom Scheme if relativeURL is provided
             self.updateRelativeUri(line: line)
 
-            switch line.tag {
-            case ManifestTags.ExtInf.rawValue:
+            if line.tag == ManifestTags.ExtInf.rawValue {
                 guard let duration = Double(lineString.filter("0123456789.".contains)) else {
                     return
                 }
                 self.totalPlayListDuration += duration
                 self.constructedManifestArray.append(line.joinLine())
-                if let nextLine = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
-                    if nextLine.hasPrefix("#EXT-X-BYTERANGE") {
-                        self.constructedManifestArray.append(nextLine)
-                        if let segmentLine = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
-                            if let fullURL = self.getFullURL(from: segmentLine) {
-                                self.constructedManifestArray.append(fullURL.absoluteString)
-                            }
-                        }
-                    } else if let fullURL = self.getFullURL(from: nextLine) {
-                        self.constructedManifestArray.append(fullURL.absoluteString)
-                    }
+            } else if !lineString.hasPrefix("#") {
+                // lineString is a segmentUrl
+                if let fullURL = self.getFullURL(from: lineString) {
+                    self.constructedManifestArray.append(fullURL.absoluteString)
                 }
-            default:
+            } else {
                 self.constructedManifestArray.append(line.joinLine())
             }
         }

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/VariantPlaylistParser.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/Parsers/VariantPlaylistParser.swift
@@ -48,7 +48,7 @@ class VariantPlaylistParser: PlaylistParser {
         let allLines = manifestString.components(separatedBy: "\n")
         var iterator = allLines.makeIterator()
         
-        while let lineString = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines).removingPercentEncoding {
+        while let lineString = iterator.next()?.trimmingCharacters(in: .whitespacesAndNewlines) {
             let line = HLSLine(lineString: lineString)
             // we need this to force-use the absoluteURL in any URI parameter in a line
             // the reason for this behaviour is that AVPlayer will use the custom Scheme if relativeURL is provided


### PR DESCRIPTION
Conditions when bug occurs: 
- the relative paths in the playlist contain percentencoding
- the variant playlists contain EXT-X-BYTERANGE tags

This results in:
- our conversion code that makse all paths absolute adds a second percentEncoding, turning MK-CB-S01E05-es-419-227%20Soy%20una%20tazaUHD.m3u8 into MK-CB-S01E05-es-419-227%2520Soy%2520una%2520tazaUHD.m3u8 where each % is converted into %25
- our variantParser is assuming that the line after an EXTINF tag is always the segment url. In this case there is also an EXT-X-BYTERANGE tag, as supported by HSL spec.

**Fixes in the PR:**
- remove the percentEncoding when parsing the lines from the playlists
- take into account the possibility that there is an EXT-X-BYTERANGE after the EXTINF tag