### PR TITLE
Bugfix/fix content info lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Conviva
+  - Fixed an issue where reported contentInfo was not cleaned up correctly when starting a new viewing session.
+
+## [7.2.0] - 2024-04-24
+
+### Fixed
+
 - SideloadedSubtitle
   - Fixed an issue where playlists that contain urls with percentEncoding got an extra percentEncoding pass resulting in erronneous urls.
   - Fixed an issue where variant playlists with additional tags between EXTINF and the segment url, where not properly processed.

--- a/Code/Conviva/Source/ConvivaConnector.swift
+++ b/Code/Conviva/Source/ConvivaConnector.swift
@@ -54,6 +54,7 @@ public struct ConvivaConnector {
         
     public func setContentInfo(_ contentInfo: [String: Any]) {
         self.endPoints?.videoAnalytics.setContentInfo(contentInfo)
+        self.storeViewerId(contentInfo)
     }
         
     public func setAdInfo(_ adInfo: [String: Any]) {
@@ -69,8 +70,11 @@ public struct ConvivaConnector {
     }
         
     public func stopAndStartNewSession(contentInfo: [String: Any]) {
+        self.storeViewerId(contentInfo)
         self.endPoints?.videoAnalytics.reportPlaybackEnded()
-        self.endPoints?.videoAnalytics.reportPlaybackRequested(contentInfo)
+        self.endPoints?.videoAnalytics.cleanup()
+        let extendedContentInfo = Utilities.extendedContentInfo(contentInfo: contentInfo, storage: self.storage)
+        self.endPoints?.videoAnalytics.reportPlaybackRequested(extendedContentInfo)
         self.endPoints?.videoAnalytics.reportPlaybackMetric(CIS_SSDK_PLAYBACK_METRIC_PLAYER_STATE, value: PlayerState.CONVIVA_PLAYING.rawValue)
         if let bitrate = self.storage.valueForKey(CIS_SSDK_PLAYBACK_METRIC_BITRATE) as? NSNumber {
             self.endPoints?.videoAnalytics.reportPlaybackMetric(CIS_SSDK_PLAYBACK_METRIC_BITRATE, value: bitrate)
@@ -79,5 +83,11 @@ public struct ConvivaConnector {
         
     public func setErrorCallback(onNativeError: (([String: Any]) -> Void)? ) {
         self.convivaVPFDetector.setVideoPlaybackFailureCallback(onNativeError)
+    }
+    
+    private func storeViewerId(_ contentInfo: [String: Any]) {
+        if let viewerId = contentInfo[CIS_SSDK_METADATA_VIEWER_ID] as? String {
+            self.storage.storeKeyValuePair(key: CIS_SSDK_METADATA_VIEWER_ID, value: viewerId)
+        }
     }
 }

--- a/Code/Conviva/Source/ConvivaConnectorStorage.swift
+++ b/Code/Conviva/Source/ConvivaConnectorStorage.swift
@@ -19,7 +19,7 @@ public class ConvivaConnectorStorage {
         return self.storedValues[key]
     }
     
-    func clear() {
-        self.storedValues.removeAll()
+    func clearValueForKey(_ key: String) {
+        self.storedValues.removeValue(forKey: key)
     }
 }

--- a/Code/Conviva/Source/Utilities/Utilities.swift
+++ b/Code/Conviva/Source/Utilities/Utilities.swift
@@ -10,16 +10,28 @@ import THEOplayerSDK
 import AVFoundation
 
 enum Utilities {
-    static let playerFrameworkName = "THEOplayer"
+    static let playerName = "THEOplayer"
+    static let playerVersion = THEOplayer.version
     
     static let playerInfo = [
-        CIS_SSDK_PLAYER_FRAMEWORK_NAME: playerFrameworkName,
-        CIS_SSDK_PLAYER_FRAMEWORK_VERSION: THEOplayer.version
-    ]
+            CIS_SSDK_PLAYER_FRAMEWORK_NAME: playerName,
+            CIS_SSDK_PLAYER_FRAMEWORK_VERSION: THEOplayer.version
+        ]
     
     static let defaultStringValue = "NA"
     
     static let en_usLocale = Locale(identifier: "en_US")
+    
+    static func extendedContentInfo(contentInfo: [String: Any], storage: ConvivaConnectorStorage?) -> [String: Any] {
+        var extendedContentInfo = contentInfo
+        if let viewerId = storage?.valueForKey(CIS_SSDK_METADATA_VIEWER_ID) as? String {
+            extendedContentInfo.updateValue(viewerId, forKey: CIS_SSDK_METADATA_VIEWER_ID)
+        }
+        extendedContentInfo.updateValue(Utilities.playerName, forKey: CIS_SSDK_METADATA_PLAYER_NAME)
+        extendedContentInfo.updateValue(Utilities.playerName, forKey: CIS_SSDK_PLAYER_FRAMEWORK_NAME)
+        extendedContentInfo.updateValue(Utilities.playerVersion, forKey: CIS_SSDK_PLAYER_FRAMEWORK_VERSION)
+        return extendedContentInfo
+    }
 }
 
 extension THEOplayer {


### PR DESCRIPTION
Now calling cleanup when ending the viewer session, which clears the videoAnalytics contentInfo. But keeping some of the initially reported contentInfo: like ViewerId, PlayerName, FrameworkName and version.