### PR TITLE
add update_changelog script; update action to run script

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -53,6 +53,15 @@ jobs:
           git add version.json
           git commit -m "update version.json"
           git push
+      - name: Update CHANGELOG.md file
+        if: inputs.version != '' && inputs.dryRun == false
+        run: sh update_changelog.sh -v ${{ inputs.version }}
+      - name: Commit and push the changes made to the CHANGELOG.md file
+        if: inputs.version != '' && inputs.dryRun == false
+        run: |
+          git add CHANGELOG.md
+          git commit -m "update CHANGELOG.md"
+          git push
       - name: Add and push new git tag
         if: inputs.version != ''
         run: |

--- a/update_changelog.sh
+++ b/update_changelog.sh
@@ -1,0 +1,17 @@
+while getopts "v:" opt
+do
+   case "$opt" in
+      v ) version="$OPTARG" ;;
+   esac
+done
+if [ -z "$version" ]
+then
+   echo "Missing argument: 'version'. Usage: \$sh update_changelog.sh -v 1.0.0"
+fi
+
+v=$version
+file_path="./CHANGELOG.md"
+date=$(date +"%Y-%m-%d")
+
+# Replace the line containing "## Unreleased" with new version and date
+sed -i '' -e "s/^## Unreleased$/## [$v] - $date/" "$file_path"


### PR DESCRIPTION
Adding an extra step to update the CHANGELOG file with the release version before tagging the repo.
This means there is no longer need to manually update the CHANGELOG before release.
It will find the `## Unreleased` mark and replace it with the current version and date.