### PR TITLE
Bugfix/vpf detection rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Conviva
+	- Fixed an issue where multiple fatal errors were reported to the Conviva backend, resulting in multiple sessions being created.
+	- Fixed an issue where VPF was not detected for VOD when the player has enough buffered data to get passed the detection interval. 
+
 ## [7.9.0] - 2024-08-01
 
 ### Fixed

--- a/Code/Conviva/Source/ConvivaConnector.swift
+++ b/Code/Conviva/Source/ConvivaConnector.swift
@@ -63,7 +63,7 @@ public struct ConvivaConnector {
     }
         
     public func reportPlaybackFailed(message: String) {
-        self.endPoints?.videoAnalytics.reportPlaybackFailed(message, contentInfo: nil)
+        self.basicEventForwarder?.reportFatalError(message: message)
     }
     
     public func reportPlaybackEvent(eventType: String, eventDetail: [String: Any]) {

--- a/Code/Conviva/Source/ConvivaConnector.swift
+++ b/Code/Conviva/Source/ConvivaConnector.swift
@@ -22,7 +22,7 @@ public struct ConvivaConnector {
     
     init(conviva: ConvivaEndpoints, player: THEOplayer, externalEventDispatcher: THEOplayerSDK.EventDispatcherProtocol? = nil) {
         self.endPoints = conviva
-        
+        self.convivaVPFDetector.player = player
         if let endPoints = self.endPoints {
             self.appEventForwarder = AppEventForwarder(player: player,
                                                   eventProcessor: AppEventConvivaReporter(analytics: endPoints.analytics,
@@ -50,6 +50,7 @@ public struct ConvivaConnector {
         
     public func destroy() {
         self.endPoints?.destroy()
+        self.basicEventForwarder?.destroy()
     }
         
     public func setContentInfo(_ contentInfo: [String: Any]) {

--- a/Code/Conviva/Source/ConvivaVPFDetector.swift
+++ b/Code/Conviva/Source/ConvivaVPFDetector.swift
@@ -44,7 +44,7 @@ class ConvivaVPFDetector {
     func transitionToWaiting() {
         guard self.stallCheckTimer == nil else {
             // already in a waiting state...
-            self.vpfLog("[VPF-DETECTOR] Already checking the waiting state...")
+            self.vpfLog("Already checking the waiting state...")
             return
         }
         
@@ -57,7 +57,7 @@ class ConvivaVPFDetector {
                 self?.stallCheckTimer = nil
             }
         })
-        self.vpfLog("[VPF-DETECTOR] Transitioned to waiting.")
+        self.vpfLog("Transitioned to waiting.")
     }
     
     func reset() {
@@ -67,7 +67,7 @@ class ConvivaVPFDetector {
         if self.stallCheckTimer != nil {
             self.stallCheckTimer?.invalidate()
             self.stallCheckTimer = nil;
-            self.vpfLog("[VPF-DETECTOR] Detector is reset.")
+            self.vpfLog("Detector is reset.")
         }
     }
 
@@ -78,18 +78,18 @@ class ConvivaVPFDetector {
                let eventTimestamp = event.date?.timeIntervalSince1970,
                let lastResetTimestamp = self.lastMarkedReset,
                eventTimestamp > lastResetTimestamp {
-                self.vpfLog("[VPF-DETECTOR] Severe errorLog event found at \((eventTimestamp - lastResetTimestamp)) sec from reset. (\(event.errorComment ?? "no comment"))")
+                self.vpfLog("Severe errorLog event found at \((eventTimestamp - lastResetTimestamp)) sec from reset. (\(event.errorComment ?? "no comment"))")
                 errorCountWithinDetectionRange += 1
             }
         }
         let nowT = Date().timeIntervalSince1970
         let detectionRange = nowT - (self.lastMarkedReset ?? nowT)
         if errorCountWithinDetectionRange >= self.errorCountTreshold {
-            self.vpfLog("[VPF-DETECTOR] VPF detected. \(errorCountWithinDetectionRange) severe errors within detection range (last \(detectionRange) sec).")
+            self.vpfLog("VPF detected. \(errorCountWithinDetectionRange) severe errors within detection range (last \(detectionRange) sec).")
             self.videoPlaybackFailureCallback?(self.vpfErrorDictionary)
             self.delegate?.onVPFDetected()
         } else {
-            self.vpfLog("[VPF-DETECTOR] Stall interpreted as not caused by network error. Only \(errorCountWithinDetectionRange) severe errors within detection range (last \(detectionRange) sec).")
+            self.vpfLog("Stall interpreted as not caused by network error. Only \(errorCountWithinDetectionRange) severe errors within detection range (last \(detectionRange) sec).")
         }
     }
     
@@ -99,7 +99,7 @@ class ConvivaVPFDetector {
     
     private func vpfLog(_ logString: String) {
         if DEBUG_VPF {
-            print(logString)
+            print("[DEBUG-VPF]", logString)
         }
     }
 }

--- a/Code/Conviva/Source/Events/ConvivaReporters/BasicEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/BasicEventConvivaReporter.swift
@@ -5,7 +5,7 @@
 import ConvivaSDK
 import THEOplayerSDK
 
-class BasicEventConvivaReporter: BasicEventProcessor {
+class BasicEventConvivaReporter {
     
     struct Session {
         struct Source {

--- a/Code/Conviva/Source/Events/ConvivaReporters/BasicEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/BasicEventConvivaReporter.swift
@@ -59,7 +59,11 @@ class BasicEventConvivaReporter {
     }
     
     func error(event: ErrorEvent) {
-        self.videoAnalytics.reportPlaybackFailed(event.error, contentInfo: nil)
+        if self.currentSession.started {
+            self.videoAnalytics.reportPlaybackFailed(event.error, contentInfo: nil)
+            // the reportPlaybackFailed will close the session on the Conviva backend.
+            self.currentSession.started = false
+        }
     }
     
     func networkError(event: NetworkErrorEvent) {

--- a/Code/Conviva/Source/Events/Observers/BasicEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/BasicEventForwarder.swift
@@ -88,7 +88,11 @@ class BasicEventForwarder: VPFDetectordelegate {
     }
     
     func onVPFDetected() {
-        self.eventProcessor?.error(event: ErrorEvent(error: "Network Error", errorObject: nil, date: Date()))
+        self.reportFatalError(message: "Network Error")
         self.player?.stop()
+    }
+    
+    func reportFatalError(message: String, errorObject: THEOplayerSDK.THEOError? = nil, date: Date = Date()) {
+        self.eventProcessor?.error(event: ErrorEvent(error: message, errorObject: errorObject, date: date))
     }
 }


### PR DESCRIPTION
- **Changed the VPF detection** to a waiting event + timer setup instead of waiting event + pause event. It was observed that for some streams (mostly VOD) AVplayer does not trigger the pause (and even keeps incrementing the currentTime whereas the stream has stopped).

- Last VPF reset timestamp (marking the stream is fine) is kept as start of the longer interval for which errorLog is monitored. This replaces the fixed interval that sometimes (when player has sufficient buffer) fell out of the timeranges containing the actual errors.

- As requested by Conviva: **Prevent multiple fatal errors** being reported during 1 viewer session. as this would cause multiple sessions being created on the Conviva backend, with huge negative impact on the player SPI.