### PR TITLE
always add synchronous flag to pod trunk operations

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -100,12 +100,8 @@ jobs:
           fi
           for connector in ${connectors[*]}
           do
-            extraFlags=""
-            if [[ $connector == *Conviva.podspec ]]; then
-                extraFlags+="--synchronous"
-            fi
             pod repo update
-            pod $command $connector --verbose --allow-warnings $extraFlags
+            pod $command $connector --verbose --allow-warnings --synchronous
           done
   Cleanup:
     needs: Bump-And-Release


### PR DESCRIPTION
The workflow failed because it couldn't find the newly released `8.0.0` THEOplayerSDK-core pod.
I can try re-running as is, but it makes sense to add the `synchronous` flag here. Quoting from the Cocoapods docs:

> --synchronous | If validation depends on other recently pushed pods, synchronize.

This is always the case for our release builds, so removing the condition of only when Conviva.