### PR TITLE
Bugfix/vpf detector missing player reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Conviva
+	- Fixed an issue where the vpfDetector was not firing a VPF due to a missing player reference.
+
 ## [7.10.0] - 2024-08-13
 
 ### Fixed

--- a/Code/Conviva/Source/ConvivaConnector.swift
+++ b/Code/Conviva/Source/ConvivaConnector.swift
@@ -8,7 +8,6 @@ import ConvivaSDK
 /// Connects to a THEOplayer instance and reports its events to conviva
 public struct ConvivaConnector {
     private let storage = ConvivaConnectorStorage()
-    private let convivaVPFDetector = ConvivaVPFDetector()
     
     private var endPoints: ConvivaEndpoints
     private var appEventForwarder: AppEventForwarder
@@ -28,7 +27,6 @@ public struct ConvivaConnector {
                                                                                            adAnalytics: endPoints.adAnalytics,
                                                                                            storage: self.storage))
         self.basicEventForwarder = BasicEventForwarder(player: player,
-                                                       vpfDetector: self.convivaVPFDetector,
                                                        eventProcessor: BasicEventConvivaReporter(videoAnalytics: endPoints.videoAnalytics,
                                                                                                  storage: self.storage))
         self.adEventHandler = AdEventForwarder(player: player,
@@ -73,7 +71,7 @@ public struct ConvivaConnector {
     }
     
     public func setErrorCallback(onNativeError: (([String: Any]) -> Void)? ) {
-        self.convivaVPFDetector.setVideoPlaybackFailureCallback(onNativeError)
+        self.basicEventForwarder.setVideoPlaybackFailureCallback(onNativeError)
     }
     
     private func storeViewerId(_ contentInfo: [String: Any]) {

--- a/Code/Conviva/Source/ConvivaVPFDetector.swift
+++ b/Code/Conviva/Source/ConvivaVPFDetector.swift
@@ -24,7 +24,7 @@ protocol VPFDetectordelegate: AnyObject {
     func onVPFDetected()
 }
 
-let VPF_STALL_INTERVAL: TimeInterval = 25.0
+let VPF_STALL_INTERVAL: TimeInterval = 20.0
 let DEBUG_VPF = false
 
 class ConvivaVPFDetector {

--- a/Code/Conviva/Source/Events/Observers/BasicEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/BasicEventForwarder.swift
@@ -10,11 +10,11 @@ import AVFoundation
 class BasicEventForwarder: VPFDetectordelegate {
     private let playerObserver: DispatchObserver
     private let networkObserver: DispatchObserver
+    private let vpfDetector = ConvivaVPFDetector()
     weak var player: THEOplayer?
-    weak var vpfDetector: ConvivaVPFDetector?
     weak var eventProcessor: BasicEventConvivaReporter?
     
-    init(player: THEOplayer, vpfDetector: ConvivaVPFDetector, eventProcessor: BasicEventConvivaReporter) {
+    init(player: THEOplayer, eventProcessor: BasicEventConvivaReporter) {
         playerObserver = .init(
             dispatcher: player,
             eventListeners: Self.forwardEvents(from: player, vpfDetector: vpfDetector, to: eventProcessor)
@@ -33,13 +33,17 @@ class BasicEventForwarder: VPFDetectordelegate {
         self.player = player
         self.eventProcessor = eventProcessor
         
-        // set self as delegate for VPF detection
+        // set self as delegate for VPF detection and provide player
         vpfDetector.delegate = self
-        self.vpfDetector = vpfDetector
+        vpfDetector.player = player
     }
     
     func destroy() {
-        self.vpfDetector?.reset()
+        self.vpfDetector.reset()
+    }
+    
+    func setVideoPlaybackFailureCallback(_ videoPlaybackFailureCallback: (([String: Any]) -> Void)? ) {
+        self.vpfDetector.setVideoPlaybackFailureCallback(videoPlaybackFailureCallback)
     }
     
     static func forwardEvents(from player: THEOplayer, vpfDetector: ConvivaVPFDetector, to processor: BasicEventConvivaReporter) -> [RemovableEventListenerProtocol] {


### PR DESCRIPTION
Passing player to VPFDetector to access its errorLog
+ refactor that moves VPF detector completely inside BasicEventForwarder