### PR TITLE
Fix Conviva SDK version in Package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Conviva
+  - Fixed an issue where the bitrate change events were reported to the incorrect Conviva endpoint.
+
 ## [8.12.0] - 2025-02-26
 
 ### Changed

--- a/Code/Conviva/Source/ConvivaConnector.swift
+++ b/Code/Conviva/Source/ConvivaConnector.swift
@@ -43,7 +43,7 @@ public struct ConvivaConnector {
     
     public func setContentInfo(_ contentInfo: [String: Any]) {
         self.endPoints.videoAnalytics.setContentInfo(contentInfo)
-        self.storeViewerId(contentInfo)
+        self.storeClientMetadata(contentInfo)
     }
     
     public func setAdInfo(_ adInfo: [String: Any]) {
@@ -59,7 +59,7 @@ public struct ConvivaConnector {
     }
     
     public func stopAndStartNewSession(contentInfo: [String: Any]) {
-        self.storeViewerId(contentInfo)
+        self.storeClientMetadata(contentInfo)
         self.endPoints.videoAnalytics.reportPlaybackEnded()
         self.endPoints.videoAnalytics.cleanup()
         let extendedContentInfo = Utilities.extendedContentInfo(contentInfo: contentInfo, storage: self.storage)
@@ -74,9 +74,9 @@ public struct ConvivaConnector {
         self.basicEventForwarder.setVideoPlaybackFailureCallback(onNativeError)
     }
     
-    private func storeViewerId(_ contentInfo: [String: Any]) {
-        if let viewerId = contentInfo[CIS_SSDK_METADATA_VIEWER_ID] as? String {
-            self.storage.storeKeyValuePair(key: CIS_SSDK_METADATA_VIEWER_ID, value: viewerId)
+    private func storeClientMetadata(_ contentInfo: [String: Any]) {
+        contentInfo.forEach { (key, value) in
+            self.storage.clientMetadata[key] = value
         }
     }
 }

--- a/Code/Conviva/Source/ConvivaConnectorStorage.swift
+++ b/Code/Conviva/Source/ConvivaConnectorStorage.swift
@@ -5,6 +5,8 @@
 public class ConvivaConnectorStorage {
     private var storedValues: [String:Any] = [:]
     
+    public var clientMetadata: [String: Any] = [:]
+    
     public func storeKeyValuePair(key: String, value: Any) {
         self.storedValues.updateValue(value, forKey: key)
     }

--- a/Code/Conviva/Source/Events/ConvivaReporters/AppEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/AppEventConvivaReporter.swift
@@ -37,6 +37,9 @@ class AppEventConvivaReporter: AppEventProcessor {
         adLoaded = false
     }
     
+    func sourceChanged(event: THEOplayerSDK.SourceChangeEvent) {
+        self.reset()
+    }
     
     func appWillEnterForeground(notification: Notification) {
         self.analytics.reportAppForegrounded()
@@ -88,5 +91,11 @@ class AppEventConvivaReporter: AppEventProcessor {
 
         endpoint.reportPlaybackMetric(CIS_SSDK_PLAYBACK_METRIC_BITRATE, value: bitrateValue)
         self.storage.storeKeyValuePair(key: CIS_SSDK_PLAYBACK_METRIC_BITRATE, value: bitrateValue)
+    }
+
+    private func reset() {
+        self.adLoaded = false
+        self.lastPlayerItem = nil
+        self.lastAccessLogEvent = nil
     }
 }

--- a/Code/Conviva/Source/Events/ConvivaReporters/AppEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/AppEventConvivaReporter.swift
@@ -47,19 +47,21 @@ class AppEventConvivaReporter: AppEventProcessor {
     }
     
     func appGotNewAccessLogEntry(event: AVPlayerItemAccessLogEvent, item: AVPlayerItem, isPlayingAd: Bool) {
-        
-        // if we get the same bitrate for the same item in a row, we don't need to report that.
-        // I see this happens when we get an access log towards the end of an ad.
-        // as well, which might be indicating something else other than a bitrate change.
-        if lastPlayerItem == item, event.indicatedBitrate == lastAccessLogEvent?.indicatedBitrate {
-            return
-        }
-        
         // This indicates that the current access log we got belongs
         // to an ad that is not playing, we will receive the same
         // access log bitrate shortly after when we start playing, so
         // we can ignore this bitrate.
         if adLoaded, !isPlayingAd {
+            return
+        }
+        
+        // if we get the same bitrate and number of dropped frames for the same item in a row, we don't need to report that.
+        // I see this happens when we get an access log towards the end of an ad.
+        // as well, which might be indicating something else other than a bitrate change.
+        if lastPlayerItem == item,
+           event.indicatedBitrate == lastAccessLogEvent?.indicatedBitrate,
+           event.numberOfDroppedVideoFrames == event.numberOfDroppedVideoFrames
+           {
             return
         }
         

--- a/Code/Conviva/Source/Events/ConvivaReporters/AppEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/AppEventConvivaReporter.swift
@@ -4,13 +4,38 @@
 
 import ConvivaSDK
 import AVFoundation
+import THEOplayerSDK
 
-struct AppEventConvivaReporter: AppEventProcessor {
+class AppEventConvivaReporter: AppEventProcessor {
+
+    
     let analytics: CISAnalytics
     let videoAnalytics: CISVideoAnalytics
     let adAnalytics: CISAdAnalytics
     let storage: ConvivaConnectorStorage
-
+    
+    init(analytics: CISAnalytics, videoAnalytics: CISVideoAnalytics, adAnalytics: CISAdAnalytics, storage: ConvivaConnectorStorage) {
+        self.analytics = analytics
+        self.videoAnalytics = videoAnalytics
+        self.adAnalytics = adAnalytics
+        self.storage = storage
+    }
+    
+    // This is a workaround for THEOSD-14780
+    // Access log entries for preroll ads come in before the player.ads.playing is updated, which means
+    // bitrate information gets reported to the main content instead, which is incorrect.
+    // Ads get loaded always before access log entries come, which we can use to report
+    // the ad bitrate to the correct endpoint.
+    private var prerollAdPlaying: Bool = false
+    
+    func adDidLoad(event: THEOplayerSDK.AdLoadedEvent)  {
+        prerollAdPlaying = true
+    }
+    func adDidEnd(event: THEOplayerSDK.AdEndEvent)  {
+        prerollAdPlaying = false
+    }
+    
+    
     func appWillEnterForeground(notification: Notification) {
         self.analytics.reportAppForegrounded()
     }
@@ -20,8 +45,13 @@ struct AppEventConvivaReporter: AppEventProcessor {
     }
     
     func appGotNewAccessLogEntry(event: AVPlayerItemAccessLogEvent, isPlayingAd: Bool) {
-        let endpoint = isPlayingAd ? self.adAnalytics : self.videoAnalytics
-
+        // If the ad did load but we haven't started playing it,
+        // we will report the bitrate to the ad endpoint regardless.
+        // Previously, we were incorrectly reporting to the video endpoint
+        // when the ad loaded but was not playing.
+        let toSendToAdEndpoint = prerollAdPlaying || isPlayingAd
+        let endpoint = toSendToAdEndpoint ? self.adAnalytics : self.videoAnalytics
+        
         self.handleBitrateChange(bitrate: event.indicatedBitrate, endpoint: endpoint)
         
         if event.numberOfDroppedVideoFrames >= 0 {
@@ -30,7 +60,8 @@ struct AppEventConvivaReporter: AppEventProcessor {
     }
 
     func appGotBitrateChangeEvent(bitrate: Double, isPlayingAd: Bool) {
-        let endpoint = isPlayingAd ? self.adAnalytics : self.videoAnalytics
+        let toSendToAdEndpoint = prerollAdPlaying || isPlayingAd
+        let endpoint = toSendToAdEndpoint ? self.adAnalytics : self.videoAnalytics
         self.handleBitrateChange(bitrate: bitrate, endpoint: endpoint)
     }
 

--- a/Code/Conviva/Source/Events/ConvivaReporters/BasicEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/BasicEventConvivaReporter.swift
@@ -93,6 +93,7 @@ class BasicEventConvivaReporter {
             ] as [String: Any]
             self.videoAnalytics.setContentInfo(contentInfo)
             self.storage.storeKeyValuePair(key: CIS_SSDK_METADATA_ASSET_NAME, value: assetName)
+            self.storage.storeKeyValuePair(key: CIS_SSDK_METADATA_STREAM_URL, value: url)
         } else {
             newSource = nil
             #if DEBUG

--- a/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
@@ -49,7 +49,7 @@ class AppEventForwarder {
                 guard item == player.currentItem else { return } // TODO: Remove this.
 
                 // BUGFIX: There is a case where we get the ad bitrate reported as a new log entry
-                eventProcessor.appGotNewAccessLogEntry(event: event, isPlayingAd: player.ads.playing)
+                eventProcessor.appGotNewAccessLogEntry(event: event, item: item, isPlayingAd: player.ads.playing)
             }
         )
         // Temporary workaround for THEOlive bitrate change events
@@ -102,6 +102,6 @@ protocol AppEventProcessor {
     func adDidEnd(event: AdEndEvent)
     func appWillEnterForeground(notification: Notification)
     func appDidEnterBackground(notification: Notification)
-    func appGotNewAccessLogEntry(event: AVPlayerItemAccessLogEvent, isPlayingAd: Bool)
+    func appGotNewAccessLogEntry(event: AVPlayerItemAccessLogEvent, item: AVPlayerItem, isPlayingAd: Bool)
     func appGotBitrateChangeEvent(bitrate: Double, isPlayingAd: Bool)
 }

--- a/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
@@ -21,6 +21,7 @@ class AppEventForwarder {
     let foregroundObserver, backgroundObserver, accessLogObserver, bitrateChangeObserver: Any
     let adsLoadedEventListener: RemovableEventListenerProtocol?
     let adsEndEventListener: RemovableEventListenerProtocol?
+    let sourceChangeEventListener: RemovableEventListenerProtocol?
 
     let player: THEOplayer
     
@@ -83,6 +84,13 @@ class AppEventForwarder {
             }
         }
         
+        sourceChangeEventListener = player.addRemovableEventListener(
+            type: PlayerEventTypes.SOURCE_CHANGE
+        ) { event in
+            DispatchQueue.main.async {
+                eventProcessor.sourceChanged(event: event)
+            }
+        }
     }
     
     deinit {
@@ -92,6 +100,7 @@ class AppEventForwarder {
         center.removeObserver(accessLogObserver, name: bitrateChangeEvent, object: nil)
         adsLoadedEventListener?.remove(from: player.ads)
         adsEndEventListener?.remove(from: player.ads)
+        sourceChangeEventListener?.remove(from: player)
 
     }
 }
@@ -100,6 +109,7 @@ protocol AppEventProcessor {
     // Workaround for THEOSD-14780
     func adDidLoad(event: AdLoadedEvent)
     func adDidEnd(event: AdEndEvent)
+    func sourceChanged(event: SourceChangeEvent)
     func appWillEnterForeground(notification: Notification)
     func appDidEnterBackground(notification: Notification)
     func appGotNewAccessLogEntry(event: AVPlayerItemAccessLogEvent, item: AVPlayerItem, isPlayingAd: Bool)

--- a/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
@@ -5,6 +5,7 @@
 import UIKit
 import THEOplayerSDK
 import AVFoundation
+import THEOplayerConnectorUtilities
 
 fileprivate let willEnterForeground = UIApplication.willEnterForegroundNotification
 fileprivate let didEnterBackground = UIApplication.didEnterBackgroundNotification
@@ -18,6 +19,9 @@ fileprivate let bitrateChangeEvent = Notification.Name("THEOliveBitrateChangeEve
 class AppEventForwarder {
     let center = NotificationCenter.default
     let foregroundObserver, backgroundObserver, accessLogObserver, bitrateChangeObserver: Any
+    let adsLoadedEventListener: RemovableEventListenerProtocol?
+    let adsEndEventListener: RemovableEventListenerProtocol?
+
     let player: THEOplayer
     
     init(player: THEOplayer, eventProcessor: AppEventProcessor) {
@@ -38,12 +42,13 @@ class AppEventForwarder {
         accessLogObserver = center.addObserver( // TODO: implement this in THEOplayerSDK using an observer on the correct player item so we can remove src URL checks
             forName: newAccessLogEntry,
             object: .none,
-            queue: .none,
+            queue: OperationQueue.main,
             using: { [unowned player] notification in
                 guard let item = notification.object as? AVPlayerItem else {return}
                 guard let event = item.accessLog()?.events.last else {return}
                 guard item == player.currentItem else { return } // TODO: Remove this.
 
+                // BUGFIX: There is a case where we get the ad bitrate reported as a new log entry
                 eventProcessor.appGotNewAccessLogEntry(event: event, isPlayingAd: player.ads.playing)
             }
         )
@@ -57,10 +62,27 @@ class AppEventForwarder {
             using: { notification in
                 guard let userInfo = notification.userInfo else { return }
                 guard let bitrate = userInfo["bitrate"] as? Double else { return }
-
+                
                 eventProcessor.appGotBitrateChangeEvent(bitrate: bitrate, isPlayingAd: player.ads.playing)
             }
         )
+        
+        
+        adsLoadedEventListener = player.ads.addRemovableEventListener(
+            type: AdsEventTypes.AD_LOADED
+        ) { event in
+            DispatchQueue.main.async {
+                eventProcessor.adDidLoad(event: event)
+            }
+        }
+        adsEndEventListener = player.ads.addRemovableEventListener(
+            type: AdsEventTypes.AD_END
+        ) { event in
+            DispatchQueue.main.async {
+                eventProcessor.adDidEnd(event: event)
+            }
+        }
+        
     }
     
     deinit {
@@ -68,10 +90,16 @@ class AppEventForwarder {
         center.removeObserver(backgroundObserver, name: didEnterBackground, object: nil)
         center.removeObserver(accessLogObserver, name: newAccessLogEntry, object: nil)
         center.removeObserver(accessLogObserver, name: bitrateChangeEvent, object: nil)
+        adsLoadedEventListener?.remove(from: player.ads)
+        adsEndEventListener?.remove(from: player.ads)
+
     }
 }
 
 protocol AppEventProcessor {
+    // Workaround for THEOSD-14780
+    func adDidLoad(event: AdLoadedEvent)
+    func adDidEnd(event: AdEndEvent)
     func appWillEnterForeground(notification: Notification)
     func appDidEnterBackground(notification: Notification)
     func appGotNewAccessLogEntry(event: AVPlayerItemAccessLogEvent, isPlayingAd: Bool)

--- a/Code/Conviva/Source/Utilities/Utilities.swift
+++ b/Code/Conviva/Source/Utilities/Utilities.swift
@@ -23,13 +23,30 @@ enum Utilities {
     static let en_usLocale = Locale(identifier: "en_US")
     
     static func extendedContentInfo(contentInfo: [String: Any], storage: ConvivaConnectorStorage?) -> [String: Any] {
-        var extendedContentInfo = contentInfo
-        if let viewerId = storage?.valueForKey(CIS_SSDK_METADATA_VIEWER_ID) as? String {
+        var extendedContentInfo: [String: Any] = [:]
+        if let viewerId = storage?.clientMetadata[CIS_SSDK_METADATA_VIEWER_ID] as? String {
             extendedContentInfo.updateValue(viewerId, forKey: CIS_SSDK_METADATA_VIEWER_ID)
+        }
+        if let assetName = storage?.clientMetadata[CIS_SSDK_METADATA_ASSET_NAME] as? String {
+            extendedContentInfo.updateValue(assetName, forKey: CIS_SSDK_METADATA_ASSET_NAME)
+        } else if let assetName = storage?.valueForKey(CIS_SSDK_METADATA_ASSET_NAME) as? String {
+            extendedContentInfo.updateValue(assetName, forKey: CIS_SSDK_METADATA_ASSET_NAME)
+        } else {
+            extendedContentInfo.updateValue(defaultStringValue, forKey: CIS_SSDK_METADATA_ASSET_NAME)
+        }
+        if let streamUrl = storage?.valueForKey(CIS_SSDK_METADATA_STREAM_URL) as? String {
+            extendedContentInfo.updateValue(streamUrl, forKey: CIS_SSDK_METADATA_STREAM_URL)
         }
         extendedContentInfo.updateValue(Utilities.playerName, forKey: CIS_SSDK_METADATA_PLAYER_NAME)
         extendedContentInfo.updateValue(Utilities.playerName, forKey: CIS_SSDK_PLAYER_FRAMEWORK_NAME)
         extendedContentInfo.updateValue(Utilities.playerVersion, forKey: CIS_SSDK_PLAYER_FRAMEWORK_VERSION)
+        
+        storage?.clientMetadata.forEach { (key, value) in
+            extendedContentInfo[key] = value
+        }
+        contentInfo.forEach { (key, value) in
+            extendedContentInfo[key] = value
+        }
         return extendedContentInfo
     }
 }

--- a/Code/Utilities/Source/Filter.swift
+++ b/Code/Utilities/Source/Filter.swift
@@ -10,13 +10,13 @@ import Dispatch
 public class Filter {
     public typealias Function<Argument> = (Argument)->Void
     
-    let queue = DispatchQueue(label: "Filter")
+    let queue = DispatchQueue.main
     var letThrough = false
     
     public init() {}
             
-    public func sendConditionally<Argument>(argument: Argument, function: Function<Argument>) {
-        queue.sync {
+    public func sendConditionally<Argument>(argument: Argument,  function: @escaping Function<Argument>) {
+        queue.async {
             if self.letThrough {
                 function(argument)
             }
@@ -29,7 +29,7 @@ public class Filter {
     
     public func togglingSender<Argument>(_ function: @escaping Function<Argument>, setLetThroughTo newValue: Bool) -> Function<Argument> {
         { argument in
-            self.queue.sync {
+            self.queue.async {
                 self.letThrough = newValue
                 function(argument)
             }

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "THEOplayerConnectorUplynk", targets: ["THEOplayerConnectorUplynk"]),
     ],
     dependencies: [
-        .package(name: "ConvivaSDK", url: "https://github.com/Conviva/conviva-ios-sdk-spm", from: "4.0.30"),
+        .package(name: "ConvivaSDK", url: "https://github.com/Conviva/conviva-ios-sdk-spm", .exactItem( "4.0.51")),
         .package(name: "THEOplayerSDK", url: "https://github.com/THEOplayer/theoplayer-sdk-apple", from: "8.4.0"),
         .package(name: "NielsenAppApi", url: "https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-dynamic-spm-global", from: "9.0.0"),
         .package(name: "Swifter", url: "https://github.com/httpswift/swifter.git", .exactItem("1.5.0")),

--- a/THEOplayer-Connector-Conviva-VerizonMedia.podspec
+++ b/THEOplayer-Connector-Conviva-VerizonMedia.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
       
   s.static_framework = true
   s.swift_versions = ['5.3', '5.4', '5.5', '5.6', '5.7']
-  s.dependency 'ConvivaSDK', '~> 4.0.30'
+  s.dependency 'ConvivaSDK', '4.0.51'
   s.dependency 'THEOplayerSDK-core'
   s.dependency 'THEOplayer-Connector-Conviva', '4.3.1'
   s.dependency 'THEOplayer-Connector-Utilities', theoplayer_connector_version

--- a/THEOplayer-Connector-Conviva.podspec
+++ b/THEOplayer-Connector-Conviva.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
       
   s.static_framework = true
   s.swift_versions = ['5.3', '5.4', '5.5', '5.6', '5.7']
-  s.dependency 'ConvivaSDK', '~> 4.0.30'
+  s.dependency 'ConvivaSDK', '4.0.51'
   s.dependency 'THEOplayerSDK-core', "~> 8"
   s.dependency 'THEOplayer-Connector-Utilities', "~> " + theoplayer_connector_major_minor_version, ">= " + theoplayer_connector_version
 end

--- a/THEOplayer-Connector-Utilities.podspec
+++ b/THEOplayer-Connector-Utilities.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
       
   s.static_framework = true
   s.swift_versions = ['5.3', '5.4', '5.5', '5.6', '5.7']
-  s.dependency 'ConvivaSDK', '~> 4.0.30'
+  s.dependency 'ConvivaSDK', '4.0.51'
   s.dependency 'THEOplayerSDK-core', "~> 8"
 end


### PR DESCRIPTION
the current way it is setup fetches the
latest pre-release which is unstable,
as it crashes due to some unidentified
selector. I made the version fetch
the exact one just before the pre-release.