### PR TITLE
Bugfix/improve ios conviva VPF detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Conviva
+  - Improved the VPF detection for iOS and tvOS.
+
 ## [8.12.0] - 2025-02-26
 
 ### Changed

--- a/Code/Conviva/Source/ConvivaVPFDetector.swift
+++ b/Code/Conviva/Source/ConvivaVPFDetector.swift
@@ -32,7 +32,7 @@ class ConvivaVPFDetector {
     weak var delegate: VPFDetectordelegate?
     private var lastMarkedReset: TimeInterval?
     private var stallCheckTimer: Timer?
-    private let errorCountTreshold = 5
+    private let errorCountTreshold = 1
     private var videoPlaybackFailureCallback: (([String: Any]) -> Void)?
     private let vpfErrorDictionary = [
         "error": [

--- a/Code/Conviva/Source/ConvivaVPFDetector.swift
+++ b/Code/Conviva/Source/ConvivaVPFDetector.swift
@@ -24,7 +24,7 @@ protocol VPFDetectordelegate: AnyObject {
     func onVPFDetected()
 }
 
-let VPF_STALL_INTERVAL: TimeInterval = 20.0
+let VPF_STALL_INTERVAL: TimeInterval = 10.0
 let DEBUG_VPF = false
 
 class ConvivaVPFDetector {


### PR DESCRIPTION
Up till now VPF was only assumed when at least 5 severe errors were encountered in the time between the last marked working timestamp and the end of the timer based interval after the waiting event.

We noticed on both tvOS and iOS sometimes avplayer does not retry fetching 404 segments and as a result the streams get in a VPF but with only a single error as reference.

We are now considering a VPF: any 'longer' (now set to >10 sec) stall that was triggered by at least 1 severe error.