### PR TITLE
Bugfix/remove observer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Conviva
+  - Fixed a memory leak on iOS, caused by a dangling bitrate change observer on the AppEventForwarder.
+
+## [9.0.0] - 2025-04-03
+
 ### Added
 
 - Conviva
-	- Added average bitrate reporting
+  - Added average bitrate reporting
+	
 ### Fixed
 
 - Conviva

--- a/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
@@ -97,7 +97,7 @@ class AppEventForwarder {
         center.removeObserver(foregroundObserver, name: willEnterForeground, object: nil)
         center.removeObserver(backgroundObserver, name: didEnterBackground, object: nil)
         center.removeObserver(accessLogObserver, name: newAccessLogEntry, object: nil)
-        center.removeObserver(accessLogObserver, name: bitrateChangeEvent, object: nil)
+        center.removeObserver(bitrateChangeObserver, name: bitrateChangeEvent, object: nil)
         adsLoadedEventListener?.remove(from: player.ads)
         adsEndEventListener?.remove(from: player.ads)
         sourceChangeEventListener?.remove(from: player)

--- a/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
+++ b/Code/Conviva/Source/Events/Observers/AppEventForwarder.swift
@@ -17,13 +17,12 @@ fileprivate let newAccessLogEntry = Notification.Name("AVPlayerItemNewAccessLogE
 fileprivate let bitrateChangeEvent = Notification.Name("THEOliveBitrateChangeEvent")
 
 class AppEventForwarder {
-    let center = NotificationCenter.default
-    let foregroundObserver, backgroundObserver, accessLogObserver, bitrateChangeObserver: Any
-    let adsLoadedEventListener: RemovableEventListenerProtocol?
-    let adsEndEventListener: RemovableEventListenerProtocol?
-    let sourceChangeEventListener: RemovableEventListenerProtocol?
-
-    let player: THEOplayer
+    private let center = NotificationCenter.default
+    private var foregroundObserver, backgroundObserver, accessLogObserver, bitrateChangeObserver: Any
+    private var adsLoadedEventListener: RemovableEventListenerProtocol?
+    private var adsEndEventListener: RemovableEventListenerProtocol?
+    private var sourceChangeEventListener: RemovableEventListenerProtocol?
+    private weak var player: THEOplayer?
     
     init(player: THEOplayer, eventProcessor: AppEventProcessor) {
         self.player = player
@@ -98,10 +97,11 @@ class AppEventForwarder {
         center.removeObserver(backgroundObserver, name: didEnterBackground, object: nil)
         center.removeObserver(accessLogObserver, name: newAccessLogEntry, object: nil)
         center.removeObserver(bitrateChangeObserver, name: bitrateChangeEvent, object: nil)
-        adsLoadedEventListener?.remove(from: player.ads)
-        adsEndEventListener?.remove(from: player.ads)
-        sourceChangeEventListener?.remove(from: player)
-
+        if let player = self.player {
+            adsLoadedEventListener?.remove(from: player.ads)
+            adsEndEventListener?.remove(from: player.ads)
+            sourceChangeEventListener?.remove(from: player)
+        }
     }
 }
 


### PR DESCRIPTION
The removal of the wrong observer for a different eventName is causing a memory leak. The player instance cannot be broken down and as a result the stream keeps playing in a detached player instance. Audio can still be heard in the BG.