### PR TITLE
Bugfix/theoads ad duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Conviva
+  - Fixed an issue where the ad duration of a THEOad was not reported.
+
 ## [9.3.2] - 2025-05-13
 
 ### Fixed

--- a/Code/Conviva/Source/Events/ConvivaReporters/AdEventConvivaReporter.swift
+++ b/Code/Conviva/Source/Events/ConvivaReporters/AdEventConvivaReporter.swift
@@ -168,12 +168,10 @@ extension Ad {
         result["c3.ad.adStitcher"] = Utilities.defaultStringValue
         result["c3.ad.position"] = self.adBreak.calculateCurrentAdBreakPosition()
         // linearAd specific
-        if let linearAd = self as? LinearAd,
-           let duration = linearAd.duration {
+        if self.type == THEOplayerSDK.AdType.linear, let duration = self.duration {
             result[CIS_SSDK_METADATA_IS_LIVE] = false
             result[CIS_SSDK_METADATA_DURATION] = NSNumber(value: Int(duration))
         }
-        
         return result
     }
     


### PR DESCRIPTION
A THEOad does not extend a LinearAd causing the duration not being reported.