### PR TITLE
Bugfix/sideloadedsubtitles replace default duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SideloadedSubtitle
+  - Fixed an issue where enabling a `TextTrack` on the `ADD_TRACK` event would cause an error.
+
 ### Removed
 
 - Conviva
- - Removed the `setErrorCallback`. The same behaviour can be achieved in THEOplayer 10 by calling `addEventListener` on THEOplayer with a type of `PlayerEventTypes.ERROR`
+  - Removed the `setErrorCallback`. The same behaviour can be achieved in THEOplayer 10 by calling `addEventListener` on THEOplayer with a type of `PlayerEventTypes.ERROR`
 
 ## [9.6.1] - 2025-06-23
 

--- a/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/AVSubtitlesLoader.swift
+++ b/Code/Sideloaded-TextTracks/Sources/THEOplayerConnectorSideloadedSubtitle/AVSubtitlesLoader.swift
@@ -106,14 +106,18 @@ class AVSubtitlesLoader: NSObject {
         } else {
             subtitlesMediaURL = self.transformer.composeTranformationUrl(with: originalURL.absoluteString, format: format, timestamp: timestamp)
         }
+        
         // if the variantTotalDuration is equal to zero then we can use a higher number as AVPlayer is not expecting the EXACT duration but the MAXIMUM duration that the stream can reach
+        let DEFAULT_DURATION = 604800 // Corresponds to a week in seconds, as AVPplayer didn't handle Int.max as a default value well.
+        let subtitleSegmentDuration = self.variantTotalDuration == 0 ? DEFAULT_DURATION : Int(self.variantTotalDuration)
+        
         return """
         #EXTM3U
         #EXT-X-VERSION:3
         #EXT-X-MEDIA-SEQUENCE:0
         #EXT-X-PLAYLIST-TYPE:VOD
-        #EXT-X-TARGETDURATION:\(self.variantTotalDuration == 0 ? Int.max : Int(self.variantTotalDuration))
-        #EXTINF:\(self.variantTotalDuration == 0 ? String(Int.max) : String(format: "%.3f", self.variantTotalDuration))
+        #EXT-X-TARGETDURATION:\(Int(subtitleSegmentDuration))
+        #EXTINF:\(String(format: "%.3f", Double(subtitleSegmentDuration)))
         \(subtitlesMediaURL)
         #EXT-X-ENDLIST
         """


### PR DESCRIPTION
This PR fixes an issue where a 5003 error would be triggered if a `TextTrack` is enabled on the `ADD_TRACK` event for that track. 

There is a chance that the connector didn't have the chance yet to determine the content duration from a variant playlist. It would in this case use a default value of `Int.max` (for the `EXTINF` and `EXT-X-TARGETDURATION` tags in the subtitle playlist). This would cause the player to throw the 5003 error.

Now a default of 604800sec (a week) is used in this case.