### PR TITLE
Fix dry runs

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -54,8 +54,10 @@ jobs:
       - name: Commit the version.json file
         if: inputs.version != ''
         run: |
-          git add version.json
-          git commit -m "update version.json"
+          if ! git diff --quiet version.json; then
+            git add version.json
+            git commit -m "update version.json"
+          fi
       - name: Update CHANGELOG.md file
         if: inputs.version != ''
         run: sh update_changelog.sh -v ${{ inputs.version }}
@@ -67,7 +69,7 @@ jobs:
         run: |
           git tag ${{ inputs.version }}
       - name: Push changes
-        if: inputs.version != '' && inputs.dryRun == false
+        if: inputs.version != '' && inputs.version != steps.store_previous_version.outputs.previousVersion && inputs.dryRun == false
         run: |
           git push origin
           git push origin ${{ inputs.version }}

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -27,8 +27,6 @@ on:
 jobs:
   Bump-And-Release:
     runs-on: macos-14
-    outputs:
-      previousVersion: ${{ steps.store_previous_version.outputs.previousVersion }}
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -122,34 +120,3 @@ jobs:
               git checkout "$connector"
             fi
           done
-  Cleanup:
-    needs: Bump-And-Release
-    if: (inputs.dryRun == true && inputs.version != '') && (success() || failure())
-    runs-on: macos-14
-    steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.2.0'
-      - name: Check out repository code
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
-      - name: Update to latest
-        run: |
-          git fetch --all
-          git pull
-      - name: Remove and unpublish git tag
-        run: git push --delete origin refs/tags/${{ inputs.version }}
-      - name: Update(Revert) the version.json file back to the previous version
-        env:
-          PREVIOUS_VERSION: ${{ needs.Bump-And-Release.outputs.previousVersion }}
-        run: |
-          sh update_version_json.sh -v $PREVIOUS_VERSION
-      - name: Commit and push the changes made to the version.json file
-        run: |
-          diff=$(git diff version.json)
-          if [[ $diff != '' ]]; then
-            git add version.json
-            git commit -m "update version.json"
-            git push
-          fi

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -51,22 +51,25 @@ jobs:
       - name: Update the version.json file
         if: inputs.version != ''
         run: sh update_version_json.sh -v ${{ inputs.version }}
-      - name: Commit and push the changes made to the version.json file
+      - name: Commit the version.json file
         if: inputs.version != ''
         run: |
           git add version.json
           git commit -m "update version.json"
-          git push
       - name: Update CHANGELOG.md file
-        if: inputs.version != '' && inputs.dryRun == false
+        if: inputs.version != ''
         run: sh update_changelog.sh -v ${{ inputs.version }}
-      - name: Commit and push the changes made to the CHANGELOG.md file
-        if: inputs.version != '' && inputs.dryRun == false
+      - name: Commit CHANGELOG.md file
+        if: inputs.version != ''
         run: sh commit_changelog.sh
-      - name: Add and push new git tag
+      - name: Add new git tag
         if: inputs.version != ''
         run: |
           git tag ${{ inputs.version }}
+      - name: Push changes
+        if: inputs.version != '' && inputs.dryRun == false
+        run: |
+          git push origin
           git push origin ${{ inputs.version }}
       - name: ${{ (inputs.dryRun == true && 'Validate') || 'Release' }} on Cocoapods
         env:

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           xcode-version: '16.2.0'
       - name: Log stacks
+        # language=bash
         run: |
           echo "Log macOS version"
           sw_vers
@@ -43,6 +44,7 @@ jobs:
           token: ${{ secrets.ACCESS_TOKEN }}
       - id: store_previous_version
         name: Store previous version value
+        # language=bash
         run: |
           previousVersion=$(ruby -r "./THEOplayer-Connector-Version.rb" -e "print_theoplayer_connector_version")
           echo "previousVersion=$previousVersion" >> "$GITHUB_OUTPUT"
@@ -51,6 +53,7 @@ jobs:
         run: sh update_version_json.sh -v ${{ inputs.version }}
       - name: Commit the version.json file
         if: inputs.version != ''
+        # language=bash
         run: |
           if ! git diff --quiet version.json; then
             git add version.json
@@ -64,16 +67,19 @@ jobs:
         run: sh commit_changelog.sh
       - name: Add new git tag
         if: inputs.version != ''
+        # language=bash
         run: |
           git tag ${{ inputs.version }}
       - name: Push changes
         if: inputs.version != '' && inputs.version != steps.store_previous_version.outputs.previousVersion && inputs.dryRun == false
+        # language=bash
         run: |
           git push origin
           git push origin ${{ inputs.version }}
       - name: ${{ (inputs.dryRun == true && 'Validate') || 'Release' }} on Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        # language=bash
         run: |
           # make the command
           command="${{ (inputs.dryRun == true && 'spec lint') || 'trunk push' }}"


### PR DESCRIPTION
The `dryRun` option in the [Bump and release](https://github.com/THEOplayer/iOS-Connector/actions/workflows/bump-and-release.yml) workflow wasn't very dry... First, the "bump and release" job would try to commit and push a bunch of things, and then the "cleanup" job would revert those changes.

Except, if "bump and release" is run as a dry run with *the same version* as the latest version, then the "clean up" job would remove the tag for that latest version! This happened in [this run](https://github.com/THEOplayer/iOS-Connector/actions/runs/22317845992), which removed the 10.10.0 tag. We had to manually [re-create that tag](https://github.com/THEOplayer/iOS-Connector/releases/tag/10.10.0).

This reworks the workflow so dry runs don't push *anything*. Hence, they also don't need to be cleaned up, so we can't mess up the cleanup logic either. 😉