### PR TITLE
Swift compiler ver 5.3 does not support .iOS(.v15)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
`.v15` is not supported in `Package.swift` with swift tools version `5.3`. We need to bump it to `5.5`. SPM package fails to compile