### PR TITLE
Maintenance/bump xcode version 26

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -137,6 +137,10 @@ jobs:
               fi
             fi
             if [[ "${{ inputs.cocoapodsTrunk }}" == "true" ]]; then
+              if [[ $connector == *Nielsen.podspec ]]; then
+                echo "Skip Nielsen"
+                continue
+              fi
               pod repo update
               cmd="pod $command $connector $options"
               if [ ${{ inputs.dryRun }} == false ]; then

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -125,12 +125,13 @@ jobs:
           for connector in ${connectors[*]}
           do
             options="--verbose --allow-warnings"
-            if [[ $connector == *Nielsen.podspec ]]; then
-              options+=" --skip-import-validation"
-            fi
             if [[ "${{ inputs.selfHosted }}" == "true" ]]; then
               if [[ "${{ inputs.dryRun }}" != "true" ]]; then
-                pod repo push cocoapods-specs $connector $options --sources='https://cdn.cocoapods.org'
+                sources="--sources=https://cdn.cocoapods.org"
+                if [[ $connector == *Nielsen.podspec ]]; then
+                  sources+=",https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git"
+                fi
+                pod repo push cocoapods-specs $connector $options $sources'
               else
                 echo "dryRun -> skip selfHosted release"
               fi

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -131,7 +131,7 @@ jobs:
                 if [[ $connector == *Nielsen.podspec ]]; then
                   sources+=",https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git"
                 fi
-                pod repo push cocoapods-specs $connector $options $sources'
+                pod repo push cocoapods-specs $connector $options $sources
               else
                 echo "dryRun -> skip selfHosted release"
               fi

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -130,6 +130,7 @@ jobs:
                 sources="--sources=https://cdn.cocoapods.org"
                 if [[ $connector == *Nielsen.podspec ]]; then
                   sources+=",https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-specs-dynamic.git"
+                  options+=" --skip-import-validation"
                 fi
                 pod repo push cocoapods-specs $connector $options $sources
               else

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -36,7 +36,7 @@ on:
           - Uplynk
 jobs:
   Bump-And-Release:
-    runs-on: macos-14
+    runs-on: macos-26
     outputs:
       previousVersion: ${{ steps.store_previous_version.outputs.previousVersion }}
     steps:
@@ -146,7 +146,7 @@ jobs:
   Cleanup:
     needs: Bump-And-Release
     if: (inputs.dryRun == true && inputs.version != '') && (success() || failure())
-    runs-on: macos-14
+    runs-on: macos-26
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.2.0'
+          xcode-version: '26.3.0'
       - name: Log stacks
         run: |
           echo "Log macOS version"
@@ -150,7 +150,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.2.0'
+          xcode-version: '26.3.0'
       - name: Check out repository code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -123,7 +123,7 @@ jobs:
           do
             if [[ "${{ inputs.selfHosted }}" == "true" ]]; then
               if [[ "${{ inputs.dryRun }}" != "true" ]]; then
-                pod repo push cocoapods-specs $connector --verbose --allow-warnings
+                pod repo push cocoapods-specs $connector --verbose --allow-warnings --sources=https://github.com/CocoaPods/Specs/
               else
                 echo "dryRun -> skip selfHosted release"
               fi

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -32,6 +32,7 @@ on:
           - Utilities
           - Comscore
           - Conviva
+          - Nielsen
           - SideloadedSubtitle
           - Uplynk
 jobs:
@@ -100,10 +101,12 @@ jobs:
                 if [[ $file == *VerizonMedia.podspec || $file == *Nielsen.podspec || $file == *Yospace.podspec ]]; then
                   continue
                 fi
-                # Conviva validation depends on Utilities being available, which does not get published in a dry run
-                # => skip Conviva if dry run
-                if [[ $file == *Conviva.podspec && ${{ inputs.dryRun }} == true ]]; then
-                  continue
+                # Conviva and Nielsen validations depend on Utilities being available, which does not get published in a dry run
+                # => skip Conviva and Nielsen if dry run
+                if [[ ${{ inputs.dryRun }} == true ]]; then
+                  if [[ $file == *Conviva.podspec || $file == *Nielsen.podspec ]]; then
+                    continue
+                  fi
                 fi
                 connectors+=("$file")
               fi
@@ -121,16 +124,20 @@ jobs:
           fi
           for connector in ${connectors[*]}
           do
+            options="--verbose --allow-warnings"
+            if [[ $connector == *Nielsen.podspec ]]; then
+              options+=" --skip-import-validation"
+            fi
             if [[ "${{ inputs.selfHosted }}" == "true" ]]; then
               if [[ "${{ inputs.dryRun }}" != "true" ]]; then
-                pod repo push cocoapods-specs $connector --verbose --allow-warnings --sources='https://cdn.cocoapods.org'
+                pod repo push cocoapods-specs $connector $options --sources='https://cdn.cocoapods.org'
               else
                 echo "dryRun -> skip selfHosted release"
               fi
             fi
             if [[ "${{ inputs.cocoapodsTrunk }}" == "true" ]]; then
               pod repo update
-              cmd="pod $command $connector --verbose --allow-warnings"
+              cmd="pod $command $connector $options"
               if [ ${{ inputs.dryRun }} == false ]; then
                 cmd="$cmd --synchronous"
               else

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -123,7 +123,7 @@ jobs:
           do
             if [[ "${{ inputs.selfHosted }}" == "true" ]]; then
               if [[ "${{ inputs.dryRun }}" != "true" ]]; then
-                pod repo push cocoapods-specs $connector --verbose --allow-warnings --sources=https://github.com/CocoaPods/Specs/
+                pod repo push cocoapods-specs $connector --verbose --allow-warnings --sources='https://cdn.cocoapods.org'
               else
                 echo "dryRun -> skip selfHosted release"
               fi

--- a/.github/workflows/podspec-validate.yml
+++ b/.github/workflows/podspec-validate.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.2.0'
+          xcode-version: '26.3.0'
       - name: Log environment
         run: |
           echo "macOS:" && sw_vers

--- a/.github/workflows/podspec-validate.yml
+++ b/.github/workflows/podspec-validate.yml
@@ -12,7 +12,7 @@ run-name: Validating CocoaPods
 
 jobs:
   cocoapods-validate:
-    runs-on: macos-14
+    runs-on: macos-26
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1


### PR DESCRIPTION
1. Upgraded xcode to 26.3.0
2. Upgraded macOS to 26
3. Automate Nielsen releases for self hosted repo (cocoapods trunk public spec repo is still limited)