### PR TITLE
Update Yospace doc links

### DIFF
--- a/Code/Yospace/README.md
+++ b/Code/Yospace/README.md
@@ -54,8 +54,8 @@ The THEOPlayer Yospace connector has two dependency frameworks: THEOplayerSDK an
 THEOplayerSDK is added as a dependency on both Cocoapods and SPM and will be fetched by each dependency manager.
 YOAdManagement is published as a private pod hosted on Artifactory by jfrog. In order to get the framework you will need to:
 1. Setup a Yospace developer account at https://www.yospace.com/developer
-2. Login to the Yospace Apple docs https://developer.yospace.com/sdk-documentation/apple/userguide/latest/en/index-en.html
-3. Follow the instructions to setup the artifactory, authenticate, and fetch the framework at https://developer.yospace.com/sdk-documentation/apple/userguide/latest/en/prerequisites.html
+2. Login to the Yospace Apple docs at https://docs.yospace.com/library/technical/sdks/en/ad-management-sdks-v3/apple.html
+3. Follow the instructions to setup the artifactory, authenticate, and fetch the framework at https://docs.yospace.com/library/technical/sdk-api/ad-management/apple/previous/index.html
 
 ## Usage
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,15 +1,59 @@
-# THEOplayer iOS connectors
+# OptiView Player iOS SDK Connectors
 
-A collection of components that connect third party software with THEOplayer for iOS
+This repository is maintained by [Dolby OptiView](https://optiview.dolby.com/) and contains the different connectors available with the OptiView Player (formerly THEOplayer) iOS SDK.
 
--   [THEOplayer-Connector-**Conviva**](./Code/Conviva)
--   [THEOplayer-Connector-**Nielsen**](./Code/Nielsen)
--   [THEOplayer-Connector-**Comscore**](./Code/Comscore)
--   [THEOplayer-Connector-**SideloadedSubtitle**](./Code/Sideloaded-TextTracks)
--   [THEOplayer-Connector-**Yospace**](./Code/Yospace)
+The OptiView Player iOS SDK enables you to quickly deliver content playback on iOS and tvOS.
 
-## Other platforms
+Using the available connectors allows you to augment the features delivered through the iOS SDK.
+
+## Prerequisites
+
+The OptiView Player iOS SDK Connectors requires the application to import the OptiView Player iOS SDK since the connectors rely on its public APIs.
+For more details about importing OptiView Player iOS SDK check the [documentation](https://optiview.dolby.com/docs/theoplayer/getting-started/sdks/ios/getting-started/).
+
+## Available Connectors
+
+| Connector          | Dependency                                | Documentation                                         |
+| :-------------------| :------------------------------------------| :-----------------------------------------------------:|
+| Uplynk             | `THEOplayer-Connector-Uplynk`             | [documentation](Code/Uplynk/README.md)                |
+| Comscore           | `THEOplayer-Connector-Comscore`           | [documentation](Code/Comscore/README.md)              |
+| Conviva            | `THEOplayer-Connector-Conviva`            | [documentation](Code/Conviva/README.md)               |
+| Nielsen            | `THEOplayer-Connector-Nielsen`            | [documentation](Code/Nielsen/README.md)               |
+| SideloadedSubtitle | `THEOplayer-Connector-SideloadedSubtitle` | [documentation](Code/Sideloaded-TextTracks/README.md) |
+| Yospace            | `THEOplayer-Connector-Yospace`            | [documentation](Code/Yospace/README.md)               |
+
+## Installation
+
+### CocoaPods
+
+In your `Podfile` add one or more of the OptiView Player iOS SDK Connectors, for example:
+
+```ruby
+pod 'THEOplayer-Connector-Conviva'
+```
+
+### Swift Package Manager
+
+In Xcode, go to **File > Add Package Dependencies...** and add:
+
+```
+https://github.com/THEOplayer/iOS-Connector
+```
+
+Then select the library products you need (e.g. `THEOplayerConnectorConviva`).
+
+## Documentation
+
+-   [OptiView Docs](https://optiview.dolby.com/docs/)
+
+## Other Platforms
 
 If you are looking for connectors for other platforms see:
 
--   [Android-connector](https://github.com/THEOplayer/android-connector)
+-   [Android SDK connectors](https://github.com/THEOplayer/android-connector)
+-   [Web SDK connectors](https://github.com/THEOplayer/web-connectors)
+-   [React Native SDK connectors](https://github.com/THEOplayer/react-native-connectors)
+
+## License
+
+The contents of this package are subject to the [Dolby OptiView Terms of Service](https://optiview.dolby.com/policies/terms-of-service/).

--- a/Readme.md
+++ b/Readme.md
@@ -13,14 +13,17 @@ For more details about importing OptiView Player iOS SDK check the [documentatio
 
 ## Available Connectors
 
-| Connector          | Dependency                                | Supported From |                    Documentation                     |
-|:-------------------|:------------------------------------------|:--------------:|:----------------------------------------------------:|
-| Uplynk             | `THEOplayer-Connector-Uplynk`             |     8.11.1     | [documentation](Code/Uplynk/README.md)               |
-| Comscore           | `THEOplayer-Connector-Comscore`           |     4.5.0      | [documentation](Code/Comscore/README.md)             |
-| Conviva            | `THEOplayer-Connector-Conviva`            |     4.1.1      | [documentation](Code/Conviva/README.md)              |
-| Nielsen            | `THEOplayer-Connector-Nielsen`            |     4.3.0      | [documentation](Code/Nielsen/README.md)              |
-| SideloadedSubtitle | `THEOplayer-Connector-SideloadedSubtitle` |     5.2.0      | [documentation](Code/Sideloaded-TextTracks/README.md)|
-| Yospace            | `THEOplayer-Connector-Yospace`            |     7.8.0      | [documentation](Code/Yospace/README.md)              |
+| Connector          | Dependency                                | Supported From | Documentation                                         |
+| :-------------------| :------------------------------------------| :--------------:| :-----------------------------------------------------:|
+| Uplynk             | `THEOplayer-Connector-Uplynk`             | 8.11.1         | [documentation](Code/Uplynk/README.md)                |
+| Comscore           | `THEOplayer-Connector-Comscore`           | 4.5.0          | [documentation](Code/Comscore/README.md)              |
+| Conviva            | `THEOplayer-Connector-Conviva`            | 4.1.1          | [documentation](Code/Conviva/README.md)               |
+| Nielsen            | `THEOplayer-Connector-Nielsen`            | 4.3.0          | [documentation](Code/Nielsen/README.md)               |
+| SideloadedSubtitle | `THEOplayer-Connector-SideloadedSubtitle` | 5.2.0          | [documentation](Code/Sideloaded-TextTracks/README.md) |
+| Yospace            | `THEOplayer-Connector-Yospace`            | 7.8.0          | [documentation](Code/Yospace/README.md)               |
+
+Notes:
+* OptiView Player iOS SDK Connectors are compatible with a OptiView Player SDK with the same major version number. It's not recommended to use different major versions for the iOS SDK and the Connectors.
 
 ## Installation
 

--- a/Readme.md
+++ b/Readme.md
@@ -13,14 +13,14 @@ For more details about importing OptiView Player iOS SDK check the [documentatio
 
 ## Available Connectors
 
-| Connector          | Dependency                                | Documentation                                         |
-| :-------------------| :------------------------------------------| :-----------------------------------------------------:|
-| Uplynk             | `THEOplayer-Connector-Uplynk`             | [documentation](Code/Uplynk/README.md)                |
-| Comscore           | `THEOplayer-Connector-Comscore`           | [documentation](Code/Comscore/README.md)              |
-| Conviva            | `THEOplayer-Connector-Conviva`            | [documentation](Code/Conviva/README.md)               |
-| Nielsen            | `THEOplayer-Connector-Nielsen`            | [documentation](Code/Nielsen/README.md)               |
-| SideloadedSubtitle | `THEOplayer-Connector-SideloadedSubtitle` | [documentation](Code/Sideloaded-TextTracks/README.md) |
-| Yospace            | `THEOplayer-Connector-Yospace`            | [documentation](Code/Yospace/README.md)               |
+| Connector          | Dependency                                | Supported From |                    Documentation                     |
+|:-------------------|:------------------------------------------|:--------------:|:----------------------------------------------------:|
+| Uplynk             | `THEOplayer-Connector-Uplynk`             |     8.11.1     | [documentation](Code/Uplynk/README.md)               |
+| Comscore           | `THEOplayer-Connector-Comscore`           |     4.5.0      | [documentation](Code/Comscore/README.md)             |
+| Conviva            | `THEOplayer-Connector-Conviva`            |     4.1.1      | [documentation](Code/Conviva/README.md)              |
+| Nielsen            | `THEOplayer-Connector-Nielsen`            |     4.3.0      | [documentation](Code/Nielsen/README.md)              |
+| SideloadedSubtitle | `THEOplayer-Connector-SideloadedSubtitle` |     5.2.0      | [documentation](Code/Sideloaded-TextTracks/README.md)|
+| Yospace            | `THEOplayer-Connector-Yospace`            |     7.8.0      | [documentation](Code/Yospace/README.md)              |
 
 ## Installation
 


### PR DESCRIPTION
Updates Yospace doc links to the current ones.

Also rewrites the repo readme to add the missing Uplynk connector and make it similar to https://github.com/THEOplayer/android-connector#theoplayer-android-sdk-connectors.