### PR TITLE
Bump Conviva dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Conviva
+  - Bumped the Conviva SDK dependency to 4.3.1.
+
 ## [11.0.3] - 2026-05-19
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,9 @@ let package = Package(
         .library(name: "THEOplayerConnectorComscore", targets: ["THEOplayerConnectorComscore"]),
     ],
     dependencies: [
-        .package(name: "ConvivaSDK", url: "https://github.com/Conviva/conviva-ios-sdk-spm", .exactItem( "4.2.4")),
-        .package(name: "THEOplayerSDK", url: "https://github.com/THEOplayer/theoplayer-sdk-apple", from: "11.0.0"),
-        .package(name: "NielsenAppApi", url: "https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-dynamic-spm-global", from: "10.0.0"),
+        .package(name: "ConvivaSDK", url: "https://github.com/Conviva/conviva-ios-sdk-spm", "4.3.1"..<"4.4.0"),
+        .package(name: "THEOplayerSDK", url: "https://github.com/THEOplayer/theoplayer-sdk-apple", "11.0.0"..<"12.0.0"),
+        .package(name: "NielsenAppApi", url: "https://github.com/NielsenDigitalSDK/nielsenappsdk-ios-dynamic-spm-global", "10.0.0"..<"11.0.0"),
         .package(name: "Swifter", url: "https://github.com/httpswift/swifter.git", .exactItem("1.5.0")),
         .package(name: "SwiftSubtitles", url: "https://github.com/dagronf/SwiftSubtitles.git", .exactItem("0.9.1")),
         .package(name: "ComScore", url: "https://github.com/comScore/Comscore-Swift-Package-Manager", "6.10.0"..<"6.11.0"),

--- a/THEOplayer-Connector-Conviva.podspec
+++ b/THEOplayer-Connector-Conviva.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   # --- Subspec: Base (THEOplayer Conviva) ---
   s.subspec 'Base' do |base|
     base.source_files = 'Code/Conviva/Source/Base/**/*'
-    base.dependency 'ConvivaSDK', '4.2.4'
+    base.dependency 'ConvivaSDK', '~> 4.3.1'
     base.dependency 'THEOplayerSDK-core', "~> 11"
     base.dependency 'THEOplayer-Connector-Utilities', "~> " + theoplayer_connector_major_minor_version, ">= " + theoplayer_connector_version
   end


### PR DESCRIPTION
This PR bumps Conviva dependency and makes some minor changes to version ranges to make them consistent across both Cocoapods and SPM flavors.

Changelog for the Conviva library is [here](https://github.com/Conviva/conviva-ios-sdk-spm/releases).